### PR TITLE
Release v0.9.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -27,24 +27,22 @@ gobi --json media image-generate --prompt "a sunset over mountains"
 
 ## Typical Workflow (Image Generation)
 
-Always follow this two-step flow — generate, then download to vault:
+Single command — generate and download in one step:
 
 ```bash
-# Step 1: Generate (use --wait to poll until complete)
-gobi --json media image-generate --prompt "a sunset over mountains" --wait
-# → returns JSON with jobId
-
-# Step 2: Download to vault media/ folder
-gobi --json media image-download <jobId> -o media/<name>.png
+gobi --json media image-generate --prompt "a sunset over mountains" -o media/sunset.png
 ```
 
-Then show the result as an embedded vault link: `![[media/<name>.png]]`
+The `-o` flag implies `--wait` and downloads the image when done.
+
+Then show the result as an embedded vault link: `![[media/sunset.png]]`
 
 ### Key rules
+- Use `-o media/<name>.png` to generate AND download in one command. Pick a short descriptive name.
 - `--name` is **optional** — auto-derived from prompt if omitted.
-- `--wait` avoids needing a separate `image-status` call.
-- Always download with `-o media/<name>.png` — pick a short descriptive name (e.g., `happy-family.png`).
-- `image-status` takes a **positional** jobId (NOT `--job-id`): `gobi media image-status <jobId>`
+- Do NOT use the `downloadUrl` from the response — it is a frontend path, not a direct download link.
+- `image-download` takes a **positional** jobId (NOT `--job-id`): `gobi media image-download <jobId>`
+- The `jobId` (or `id`) field is what you pass to `image-download` / `image-status` — NOT `mediaId`.
 
 ## Available Commands
 

--- a/skills/gobi-media/references/media.md
+++ b/skills/gobi-media/references/media.md
@@ -152,6 +152,7 @@ Options:
   --seed <seed>                            Random seed for reproducibility
   --reference-media-id <referenceMediaId>  Reference image media ID
   --wait                                   Poll until generation completes
+  -o, --output <path>                      Download image to this path when done (implies --wait)
   -h, --help                               display help for command
 ```
 

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -368,6 +368,7 @@ export function registerMediaCommand(program: Command): void {
       "Reference image media ID",
     )
     .option("--wait", "Poll until generation completes")
+    .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
     .action(
       async (opts: {
         prompt: string;
@@ -378,7 +379,9 @@ export function registerMediaCommand(program: Command): void {
         seed?: string;
         referenceMediaId?: string;
         wait?: boolean;
+        output?: string;
       }) => {
+        const shouldWait = opts.wait || !!opts.output;
         const name = opts.name || opts.prompt.slice(0, 50).replace(/[^a-zA-Z0-9-_ ]/g, "").trim().replace(/\s+/g, "-");
         const body: Record<string, unknown> = {
           prompt: opts.prompt,
@@ -397,7 +400,7 @@ export function registerMediaCommand(program: Command): void {
         let data = unwrapResp(resp) as Record<string, unknown>;
         const jobId = data.jobId || data.id;
 
-        if (opts.wait && jobId) {
+        if (shouldWait && jobId) {
           console.log(`Image job ${jobId} queued — polling for completion…`);
           data = await pollStatus(`/media-gen/images/${jobId}`, [
             "completed",
@@ -405,6 +408,32 @@ export function registerMediaCommand(program: Command): void {
             "inference_complete",
             "inference_failed",
           ]);
+        }
+
+        // Download image to file if -o specified
+        if (opts.output && data) {
+          const id = data.jobId || data.id;
+          if (id) {
+            const token = await getValidToken();
+            const url = `${BASE_URL}/media-gen/images/${id}/download`;
+            const res = await fetch(url, {
+              headers: { Authorization: `Bearer ${token}` },
+            });
+            if (res.ok) {
+              const { writeFile, mkdir } = await import("fs/promises");
+              const { dirname } = await import("path");
+              const buffer = Buffer.from(await res.arrayBuffer());
+              await mkdir(dirname(opts.output), { recursive: true });
+              await writeFile(opts.output, buffer);
+              const contentType = res.headers.get("content-type") || "image/png";
+              if (isJsonMode(media)) {
+                jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
+                return;
+              }
+              console.log(`Image saved to ${opts.output} (${buffer.length} bytes)`);
+              return;
+            }
+          }
         }
 
         if (isJsonMode(media)) {


### PR DESCRIPTION
## Summary
- **feat:** Add `-o` flag to `image-generate` for single-command generate + download
- **fix:** Skill no longer fails from using wrong IDs or frontend `downloadUrl`
- **docs:** Skill workflow simplified to one command with clear warnings about jobId vs mediaId

🤖 Generated with [Claude Code](https://claude.com/claude-code)