### PR TITLE
[GOBI-257] Add CLI commands for cinematic video and custom avatars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 
 permissions:
   contents: write
@@ -14,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -24,16 +34,109 @@ jobs:
       - run: npm run build
       - run: npm test
 
+      # Step 1 — Bump version in package.json (also creates git tag)
+      - name: Bump version
+        id: version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          VERSION=$(node -p 'require("./package.json").version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Step 2 — Update marketplace.json and plugin.json to match
+      - name: Update marketplace & plugin versions
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Update marketplace.json top-level and plugin version
+          node -e "
+            const fs = require('fs');
+            const m = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json','utf8'));
+            m.version = '${VERSION}';
+            m.plugins.forEach(p => p.version = '${VERSION}');
+            fs.writeFileSync('.claude-plugin/marketplace.json', JSON.stringify(m, null, 2) + '\n');
+          "
+
+      # Step 3 — Regenerate skill docs
+      - name: Regenerate skill docs
+        run: npx tsx scripts/generate-skill-docs.ts
+
+      # Step 4 — Commit, tag, and push
+      - name: Commit and tag
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git add package.json package-lock.json .claude-plugin/ skills/
+          git commit -m "Bump version to ${VERSION}"
+          git tag "v${VERSION}"
+          git push
+          git push --tags
+
+      # Step 5 — Build release tarball
       - name: Pack tarball
         run: npm pack
 
+      # Step 6 — Create GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
           files: "*.tgz"
 
+      # Step 7 — Publish to npm
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Step 8 — Update Homebrew formula
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+
+          # Wait for npm registry to be available
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz")
+            if [ "$STATUS" = "200" ]; then break; fi
+            echo "Waiting for npm registry (attempt $i)..."
+            sleep 15
+          done
+
+          SHA256=$(curl -sL "https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz" | shasum -a 256 | cut -d' ' -f1)
+          URL="https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz"
+
+          node -e "
+            const fs = require('fs');
+            const formula = [
+              'class Gobi < Formula',
+              '  desc \"CLI client for the Gobi collaborative knowledge platform\"',
+              '  homepage \"https://github.com/gobi-ai/gobi-cli\"',
+              '  url \"${URL}\"',
+              '  sha256 \"${SHA256}\"',
+              '  license \"MIT\"',
+              '',
+              '  depends_on \"node\"',
+              '',
+              '  def install',
+              '    system \"npm\", \"install\", *std_npm_args',
+              '    bin.install_symlink Dir[\"#\{libexec\}/bin/*\"]',
+              '  end',
+              '',
+              '  test do',
+              '    assert_match version.to_s, shell_output(\"#\{bin\}/gobi --version\")',
+              '  end',
+              'end',
+              '',
+            ].join('\n');
+            fs.writeFileSync('/tmp/gobi-formula.rb', formula);
+          "
+
+          CONTENT=$(base64 -w0 < /tmp/gobi-formula.rb)
+          FILE_SHA=$(gh api repos/gobi-ai/homebrew-tap/contents/Formula/gobi.rb --jq .sha)
+          gh api repos/gobi-ai/homebrew-tap/contents/Formula/gobi.rb \
+            -X PUT \
+            -f message="Update gobi formula to v${VERSION}" \
+            -f content="${CONTENT}" \
+            -f sha="${FILE_SHA}"

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -3,8 +3,10 @@ name: gobi-media
 description: >-
   Gobi media generation: generate images from text prompts (thumbnails,
   assets, logos), edit and inpaint images, create avatar videos with voice
-  narration, list available avatars and voices, upload media files. Use when
-  the user wants to generate images, create videos, or manage media.
+  narration, create cinematic videos from prompts, design custom avatars or
+  create avatars from selfies, list available avatars and voices, upload
+  media files. Use when the user wants to generate images, create videos,
+  or manage media.
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
@@ -65,18 +67,56 @@ gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>"
 
 The `-o` flag implies `--wait` and downloads the video when done.
 
-**IMPORTANT: Avatars are pre-built system avatars ONLY.** You CANNOT create custom avatars from uploaded images. The `gobi media avatars` list is the complete set of available avatars. Do NOT attempt to upload an image and use its mediaId as an avatarId — it will fail.
-
-To use a custom image (e.g. a generated image) as the **background** of a video, upload it first via `upload-init` / `upload-finalize`, then pass the mediaId as `--background-media-id`:
+To use a custom image as the **background** of a video, upload it via `upload-init` / `upload-finalize`, then pass the mediaId as `--background-media-id`:
 
 ```bash
-# 1. Upload custom image as background
-gobi --json media upload-init --file-name "bg.png" --content-type "image/png" --file-size <SIZE>
-curl -T "media/bg.png" -H "Content-Type: image/png" "<UPLOAD_URL>"
-gobi --json media upload-finalize --media-id "<MEDIA_ID>"
-
-# 2. Create video with pre-built avatar + custom background
 gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>" --script "<SCRIPT>" --background-media-id "<MEDIA_ID>" -o media/<NAME>.mp4
+```
+
+## Typical Workflow (Cinematic Video)
+
+Generate a cinematic video from a text prompt (no avatar needed):
+
+```bash
+gobi --json media cinematic-create --prompt "<PROMPT>" --aspect-ratio "<RATIO>" -o media/<NAME>.mp4
+```
+
+Options: `--duration <4-8>`, `--resolution <720p|1080p>`, `--enhance-prompt`, `--generate-audio`, `--negative-prompt`, `--sample-count <1-4>`, `--first-frame-media-id`, `--last-frame-media-id`, `--reference-media-ids`.
+
+## Custom Avatars
+
+Three ways to create custom avatars:
+
+### 1. Design from scratch
+
+```bash
+gobi --json media avatar-design --name "<NAME>" --gender "<GENDER>" --age "<AGE>" --ethnicity "<ETHNICITY>" --outfit "<OUTFIT>" --background "<BACKGROUND>" --wait
+```
+
+When `variants_ready`, confirm with:
+
+```bash
+gobi --json media avatar-confirm --job-id "<JOB_ID>"
+```
+
+### 2. From a selfie (instant)
+
+```bash
+gobi --json media avatar-from-selfie --name "<NAME>" --photo-media-id "<MEDIA_ID>"
+```
+
+Upload the selfie first via `upload-init` / `upload-finalize` to get the media ID.
+
+### 3. From a selfie (enhanced with prompt)
+
+```bash
+gobi --json media avatar-from-selfie --name "<NAME>" --photo-media-id "<MEDIA_ID>" --prompt "<ENHANCEMENT>" --wait
+```
+
+Check any avatar job status with:
+
+```bash
+gobi --json media avatar-job-status <jobId> --wait
 ```
 
 **IMPORTANT: After downloading, show the video using Obsidian wiki-link syntax EXACTLY like this:**
@@ -102,10 +142,18 @@ Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs. Always use `
 ### Videos
 
 - `gobi media video-create` — Create an avatar video generation job.
+- `gobi media cinematic-create` — Create a cinematic video from a text prompt.
 - `gobi media video-list` — List all videos.
 - `gobi media video-get` — Get video metadata.
 - `gobi media video-status` — Poll video generation status.
 - `gobi media video-download` — Download a completed video (`-o` to save to file).
+
+### Custom Avatars
+
+- `gobi media avatar-design` — Start a design-your-avatar job.
+- `gobi media avatar-confirm` — Confirm avatar variant(s) after design.
+- `gobi media avatar-from-selfie` — Create an avatar from a selfie (instant or enhanced).
+- `gobi media avatar-job-status` — Check avatar job status.
 
 ### Images
 

--- a/skills/gobi-media/references/media.md
+++ b/skills/gobi-media/references/media.md
@@ -6,24 +6,29 @@ Usage: gobi media [options] [command]
 Media generation commands (videos, images).
 
 Options:
-  -h, --help                        display help for command
+  -h, --help                           display help for command
 
 Commands:
-  upload-init [options]             Get a presigned upload URL for a media file.
-  upload-finalize [options]         Confirm that a media upload is complete.
-  avatars                           List available avatars.
-  voices                            List available voices.
-  video-create [options]            Create an avatar video generation job.
-  video-list                        List all videos.
-  video-get <id>                    Get video metadata.
-  video-status [options] <id>       Poll video generation status.
-  video-download [options] <id>     Download a completed video (or get its URL).
-  image-generate [options]          Generate an image from a text prompt. Types: image (default), thumbnail (YouTube-optimized), asset (logo/product). Aspect ratios: 1:1, 16:9, 9:16, 4:3, 3:4
-  image-edit [options]              Edit an existing image with a prompt (image-to-image).
-  image-inpaint [options]           Inpaint an image region using a mask.
-  image-status [options] <jobId>    Check image generation job status.
-  image-download [options] <jobId>  Download a generated image.
-  help [command]                    display help for command
+  upload-init [options]                Get a presigned upload URL for a media file.
+  upload-finalize [options]            Confirm that a media upload is complete.
+  avatars                              List available avatars.
+  voices                               List available voices.
+  video-create [options]               Create an avatar video generation job.
+  video-list                           List all videos.
+  video-get <id>                       Get video metadata.
+  video-status [options] <id>          Poll video generation status.
+  video-download [options] <id>        Download a completed video (or get its URL).
+  cinematic-create [options]           Create a cinematic video from a text prompt.
+  avatar-design [options]              Start a design-your-avatar job.
+  avatar-confirm [options]             Confirm avatar variant(s) after design.
+  avatar-from-selfie [options]         Create an avatar from a selfie (instant or enhanced with prompt).
+  avatar-job-status [options] <jobId>  Check avatar job status.
+  image-generate [options]             Generate an image from a text prompt. Types: image (default), thumbnail (YouTube-optimized), asset (logo/product). Aspect ratios: 1:1, 16:9, 9:16, 4:3, 3:4
+  image-edit [options]                 Edit an existing image with a prompt (image-to-image).
+  image-inpaint [options]              Inpaint an image region using a mask.
+  image-status [options] <jobId>       Check image generation job status.
+  image-download [options] <jobId>     Download a generated image.
+  help [command]                       display help for command
 ```
 
 ## upload-init
@@ -137,6 +142,92 @@ Download a completed video (or get its URL).
 Options:
   -o, --output <path>  Save video to this file path
   -h, --help           display help for command
+```
+
+## cinematic-create
+
+```
+Usage: gobi media cinematic-create [options]
+
+Create a cinematic video from a text prompt.
+
+Options:
+  --prompt <prompt>                   Text prompt describing the video
+  --name <name>                       Name for the video (auto-generated if omitted)
+  --aspect-ratio <aspectRatio>        Aspect ratio: 16:9, 9:16, 1:1
+  --duration <seconds>                Duration in seconds (4-8)
+  --resolution <resolution>           Resolution: 720p, 1080p
+  --enhance-prompt                    Enhance the prompt with AI
+  --generate-audio                    Generate audio for the video
+  --negative-prompt <negativePrompt>  Negative prompt
+  --sample-count <count>              Number of samples (1-4)
+  --first-frame-media-id <mediaId>    First frame image media ID
+  --last-frame-media-id <mediaId>     Last frame image media ID
+  --reference-media-ids <ids>         Comma-separated reference image media IDs (max 3)
+  --wait                              Poll until generation completes
+  -o, --output <path>                 Download video to this path when done (implies --wait)
+  -h, --help                          display help for command
+```
+
+## avatar-design
+
+```
+Usage: gobi media avatar-design [options]
+
+Start a design-your-avatar job.
+
+Options:
+  --name <name>               Name for the avatar
+  --gender <gender>           Gender for the avatar design
+  --age <age>                 Age range for the avatar
+  --ethnicity <ethnicity>     Ethnicity for the avatar
+  --outfit <outfit>           Outfit description
+  --background <background>   Background description
+  --no-portrait               Generate full-body instead of portrait
+  --audio-media-id <mediaId>  Custom voice audio media ID
+  --wait                      Poll until variants are ready
+  -h, --help                  display help for command
+```
+
+## avatar-confirm
+
+```
+Usage: gobi media avatar-confirm [options]
+
+Confirm avatar variant(s) after design.
+
+Options:
+  --job-id <jobId>     Job ID from avatar-design
+  --variant <variant>  Variant to confirm (1 or 2); omit to confirm both
+  -h, --help           display help for command
+```
+
+## avatar-from-selfie
+
+```
+Usage: gobi media avatar-from-selfie [options]
+
+Create an avatar from a selfie (instant or enhanced with prompt).
+
+Options:
+  --name <name>               Name for the avatar
+  --photo-media-id <mediaId>  Selfie photo media ID
+  --prompt <prompt>           Enhancement prompt (triggers async enhance flow)
+  --audio-media-id <mediaId>  Custom voice audio media ID
+  --wait                      Poll until job completes (only for enhance flow)
+  -h, --help                  display help for command
+```
+
+## avatar-job-status
+
+```
+Usage: gobi media avatar-job-status [options] <jobId>
+
+Check avatar job status.
+
+Options:
+  --wait      Poll until a terminal state is reached
+  -h, --help  display help for command
 ```
 
 ## image-generate

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -25,6 +25,54 @@ async function pollStatus(
   throw new Error(`Polling timed out after ${POLL_MAX_DURATION_MS / 1000}s`);
 }
 
+/**
+ * Download a video binary from the media-gen download endpoint.
+ * Handles three cases:
+ *   1. Direct binary response (redirect: "follow" returns the file)
+ *   2. JSON response with downloadUrl (need to fetch that URL)
+ *   3. Redirect (302) with Location header
+ */
+async function downloadVideoToFile(
+  videoId: string,
+  outputPath: string,
+): Promise<{ contentType: string; size: number }> {
+  const { writeFile, mkdir } = await import("fs/promises");
+  const { dirname } = await import("path");
+  const token = await getValidToken();
+  const dlUrl = `${BASE_URL}/media-gen/videos/${videoId}/download`;
+
+  // Try following redirects first
+  const res = await fetch(dlUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    redirect: "follow",
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, `/media-gen/videos/${videoId}/download`, await res.text());
+  }
+
+  const ct = res.headers.get("content-type") || "";
+
+  // If the response is JSON, extract downloadUrl and fetch the actual binary
+  if (ct.includes("application/json")) {
+    const json = (await res.json()) as Record<string, unknown>;
+    const inner = (json.data || json) as Record<string, unknown>;
+    const url = (inner.downloadUrl || inner.download_url || inner.url) as string | undefined;
+    if (!url) throw new Error("Download endpoint returned JSON without a downloadUrl");
+    const videoRes = await fetch(url);
+    if (!videoRes.ok) throw new Error(`Failed to fetch video from ${url}: ${videoRes.status}`);
+    const buffer = Buffer.from(await videoRes.arrayBuffer());
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, buffer);
+    return { contentType: videoRes.headers.get("content-type") || "video/mp4", size: buffer.length };
+  }
+
+  // Direct binary response
+  const buffer = Buffer.from(await res.arrayBuffer());
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, buffer);
+  return { contentType: ct || "video/mp4", size: buffer.length };
+}
+
 function extractImageUrl(data: Record<string, unknown>): string | undefined {
   return (data.downloadUrl || data.download_url || data.url) as
     | string
@@ -198,7 +246,7 @@ export function registerMediaCommand(program: Command): void {
           body,
         )) as Record<string, unknown>;
         let data = unwrapResp(resp) as Record<string, unknown>;
-        const videoId = data.id || data.videoId;
+        const videoId = data.id || data.videoId || data.jobId;
 
         if (shouldWait && videoId) {
           console.log(`Video ${videoId} queued — polling for completion…`);
@@ -208,51 +256,18 @@ export function registerMediaCommand(program: Command): void {
           );
         }
 
+        // After polling, the status response may contain the real videoId for download
+        const downloadId = data.videoId || data.id || videoId;
+
         // Download video to file if -o specified
-        if (opts.output && videoId && data.status === "inference_complete") {
-          const token = await getValidToken();
-          const dlUrl = `${BASE_URL}/media-gen/videos/${videoId}/download`;
-          const dlRes = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "follow",
-          });
-          if (dlRes.ok) {
-            const { writeFile, mkdir } = await import("fs/promises");
-            const { dirname } = await import("path");
-            const buffer = Buffer.from(await dlRes.arrayBuffer());
-            await mkdir(dirname(opts.output), { recursive: true });
-            await writeFile(opts.output, buffer);
-            const contentType = dlRes.headers.get("content-type") || "video/mp4";
-            if (isJsonMode(media)) {
-              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-              return;
-            }
-            console.log(`Video saved to ${opts.output} (${buffer.length} bytes)`);
+        if (opts.output && downloadId && data.status === "inference_complete") {
+          const { contentType, size } = await downloadVideoToFile(downloadId as string, opts.output);
+          if (isJsonMode(media)) {
+            jsonOut({ ...data, filename: opts.output, contentType, size });
             return;
           }
-          // If direct download fails, try getting the URL and fetching that
-          const dlRes2 = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "manual",
-          });
-          const location = dlRes2.headers.get("location");
-          if (location) {
-            const videoRes = await fetch(location);
-            if (videoRes.ok) {
-              const { writeFile, mkdir } = await import("fs/promises");
-              const { dirname } = await import("path");
-              const buffer = Buffer.from(await videoRes.arrayBuffer());
-              await mkdir(dirname(opts.output), { recursive: true });
-              await writeFile(opts.output, buffer);
-              const contentType = videoRes.headers.get("content-type") || "video/mp4";
-              if (isJsonMode(media)) {
-                jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-                return;
-              }
-              console.log(`Video saved to ${opts.output} (${buffer.length} bytes)`);
-              return;
-            }
-          }
+          console.log(`Video saved to ${opts.output} (${size} bytes)`);
+          return;
         }
 
         if (isJsonMode(media)) {
@@ -263,12 +278,12 @@ export function registerMediaCommand(program: Command): void {
         const status = data.status || "queued";
         console.log(
           `Video created!\n` +
-            `  ID:     ${videoId}\n` +
+            `  ID:     ${downloadId}\n` +
             `  Status: ${status}`,
         );
         if (status === "inference_complete") {
           console.log(
-            `  Download: gobi media video-download ${videoId}`,
+            `  Download: gobi media video-download ${downloadId}`,
           );
         }
       },
@@ -336,49 +351,14 @@ export function registerMediaCommand(program: Command): void {
 
         // Download if -o specified and completed
         if (opts.output && data.status === "inference_complete") {
-          const token = await getValidToken();
-          const dlUrl = `${BASE_URL}/media-gen/videos/${id}/download`;
-          const dlRes = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "follow",
-          });
-          if (dlRes.ok) {
-            const { writeFile, mkdir } = await import("fs/promises");
-            const { dirname } = await import("path");
-            const buffer = Buffer.from(await dlRes.arrayBuffer());
-            await mkdir(dirname(opts.output), { recursive: true });
-            await writeFile(opts.output, buffer);
-            const contentType = dlRes.headers.get("content-type") || "video/mp4";
-            if (isJsonMode(media)) {
-              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-              return;
-            }
-            console.log(`Video ${id} — ${data.status}\nSaved to ${opts.output} (${buffer.length} bytes)`);
+          const dlId = (data.videoId || data.id || id) as string;
+          const { contentType, size } = await downloadVideoToFile(dlId, opts.output);
+          if (isJsonMode(media)) {
+            jsonOut({ ...data, filename: opts.output, contentType, size });
             return;
           }
-          // Try manual redirect
-          const dlRes2 = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "manual",
-          });
-          const location = dlRes2.headers.get("location");
-          if (location) {
-            const videoRes = await fetch(location);
-            if (videoRes.ok) {
-              const { writeFile, mkdir } = await import("fs/promises");
-              const { dirname } = await import("path");
-              const buffer = Buffer.from(await videoRes.arrayBuffer());
-              await mkdir(dirname(opts.output), { recursive: true });
-              await writeFile(opts.output, buffer);
-              const contentType = videoRes.headers.get("content-type") || "video/mp4";
-              if (isJsonMode(media)) {
-                jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-                return;
-              }
-              console.log(`Video ${id} — ${data.status}\nSaved to ${opts.output} (${buffer.length} bytes)`);
-              return;
-            }
-          }
+          console.log(`Video ${id} — ${data.status}\nSaved to ${opts.output} (${size} bytes)`);
+          return;
         }
 
         if (isJsonMode(media)) {
@@ -412,48 +392,13 @@ export function registerMediaCommand(program: Command): void {
 
       // If -o specified, download directly to file
       if (opts.output) {
-        const res = await fetch(url, {
-          headers: { Authorization: `Bearer ${token}` },
-          redirect: "follow",
-        });
-        if (res.ok) {
-          const { writeFile, mkdir } = await import("fs/promises");
-          const { dirname } = await import("path");
-          const buffer = Buffer.from(await res.arrayBuffer());
-          await mkdir(dirname(opts.output), { recursive: true });
-          await writeFile(opts.output, buffer);
-          const contentType = res.headers.get("content-type") || "video/mp4";
-          if (isJsonMode(media)) {
-            jsonOut({ filename: opts.output, contentType, size: buffer.length });
-            return;
-          }
-          console.log(`Video saved to ${opts.output} (${buffer.length} bytes)`);
+        const { contentType, size } = await downloadVideoToFile(id, opts.output);
+        if (isJsonMode(media)) {
+          jsonOut({ filename: opts.output, contentType, size });
           return;
         }
-        // If direct follow didn't work, try manual redirect
-        const res2 = await fetch(url, {
-          headers: { Authorization: `Bearer ${token}` },
-          redirect: "manual",
-        });
-        const location = res2.headers.get("location");
-        if (location) {
-          const videoRes = await fetch(location);
-          if (videoRes.ok) {
-            const { writeFile, mkdir } = await import("fs/promises");
-            const { dirname } = await import("path");
-            const buffer = Buffer.from(await videoRes.arrayBuffer());
-            await mkdir(dirname(opts.output), { recursive: true });
-            await writeFile(opts.output, buffer);
-            const contentType = videoRes.headers.get("content-type") || "video/mp4";
-            if (isJsonMode(media)) {
-              jsonOut({ filename: opts.output, contentType, size: buffer.length });
-              return;
-            }
-            console.log(`Video saved to ${opts.output} (${buffer.length} bytes)`);
-            return;
-          }
-        }
-        throw new ApiError(res.status, `/media-gen/videos/${id}/download`, "Failed to download video");
+        console.log(`Video saved to ${opts.output} (${size} bytes)`);
+        return;
       }
 
       // No -o: just return the URL (existing behavior)
@@ -560,7 +505,7 @@ export function registerMediaCommand(program: Command): void {
           body,
         )) as Record<string, unknown>;
         let data = unwrapResp(resp) as Record<string, unknown>;
-        const videoId = data.id || data.videoId;
+        const videoId = data.id || data.videoId || data.jobId;
 
         if (shouldWait && videoId) {
           console.log(`Cinematic video ${videoId} queued — polling for completion…`);
@@ -570,51 +515,18 @@ export function registerMediaCommand(program: Command): void {
           );
         }
 
+        // After polling, the status response may contain the real videoId for download
+        const downloadId = data.videoId || data.id || videoId;
+
         // Download video to file if -o specified
-        if (opts.output && videoId && data.status === "inference_complete") {
-          const token = await getValidToken();
-          const dlUrl = `${BASE_URL}/media-gen/videos/${videoId}/download`;
-          const dlRes = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "follow",
-          });
-          if (dlRes.ok) {
-            const { writeFile, mkdir } = await import("fs/promises");
-            const { dirname } = await import("path");
-            const buffer = Buffer.from(await dlRes.arrayBuffer());
-            await mkdir(dirname(opts.output), { recursive: true });
-            await writeFile(opts.output, buffer);
-            const contentType = dlRes.headers.get("content-type") || "video/mp4";
-            if (isJsonMode(media)) {
-              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-              return;
-            }
-            console.log(`Cinematic video saved to ${opts.output} (${buffer.length} bytes)`);
+        if (opts.output && downloadId && data.status === "inference_complete") {
+          const { contentType, size } = await downloadVideoToFile(downloadId as string, opts.output);
+          if (isJsonMode(media)) {
+            jsonOut({ ...data, filename: opts.output, contentType, size });
             return;
           }
-          // If direct download fails, try getting the URL and fetching that
-          const dlRes2 = await fetch(dlUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-            redirect: "manual",
-          });
-          const location = dlRes2.headers.get("location");
-          if (location) {
-            const videoRes = await fetch(location);
-            if (videoRes.ok) {
-              const { writeFile, mkdir } = await import("fs/promises");
-              const { dirname } = await import("path");
-              const buffer = Buffer.from(await videoRes.arrayBuffer());
-              await mkdir(dirname(opts.output), { recursive: true });
-              await writeFile(opts.output, buffer);
-              const contentType = videoRes.headers.get("content-type") || "video/mp4";
-              if (isJsonMode(media)) {
-                jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
-                return;
-              }
-              console.log(`Cinematic video saved to ${opts.output} (${buffer.length} bytes)`);
-              return;
-            }
-          }
+          console.log(`Cinematic video saved to ${opts.output} (${size} bytes)`);
+          return;
         }
 
         if (isJsonMode(media)) {
@@ -625,11 +537,11 @@ export function registerMediaCommand(program: Command): void {
         const status = data.status || "queued";
         console.log(
           `Cinematic video created!\n` +
-            `  ID:     ${videoId}\n` +
+            `  ID:     ${downloadId}\n` +
             `  Status: ${status}`,
         );
         if (status === "inference_complete") {
-          console.log(`  Download: gobi media video-download ${videoId}`);
+          console.log(`  Download: gobi media video-download ${downloadId}`);
         }
       },
     );

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -537,12 +537,20 @@ export function registerMediaCommand(program: Command): void {
           prompt: opts.prompt,
         };
         if (opts.aspectRatio) body.aspectRatio = opts.aspectRatio;
-        if (opts.duration) body.durationSeconds = parseInt(opts.duration, 10);
+        if (opts.duration) {
+          const v = parseInt(opts.duration, 10);
+          if (Number.isNaN(v)) throw new Error("--duration must be a number");
+          body.durationSeconds = v;
+        }
         if (opts.resolution) body.resolution = opts.resolution;
         if (opts.enhancePrompt) body.enhancePrompt = true;
         if (opts.generateAudio) body.generateAudio = true;
         if (opts.negativePrompt) body.negativePrompt = opts.negativePrompt;
-        if (opts.sampleCount) body.sampleCount = parseInt(opts.sampleCount, 10);
+        if (opts.sampleCount) {
+          const v = parseInt(opts.sampleCount, 10);
+          if (Number.isNaN(v)) throw new Error("--sample-count must be a number");
+          body.sampleCount = v;
+        }
         if (opts.firstFrameMediaId) body.firstFrameImageMediaId = opts.firstFrameMediaId;
         if (opts.lastFrameMediaId) body.lastFrameImageMediaId = opts.lastFrameMediaId;
         if (opts.referenceMediaIds) body.referenceImageMediaIds = opts.referenceMediaIds.split(",").map((s) => s.trim());
@@ -583,6 +591,29 @@ export function registerMediaCommand(program: Command): void {
             }
             console.log(`Cinematic video saved to ${opts.output} (${buffer.length} bytes)`);
             return;
+          }
+          // If direct download fails, try getting the URL and fetching that
+          const dlRes2 = await fetch(dlUrl, {
+            headers: { Authorization: `Bearer ${token}` },
+            redirect: "manual",
+          });
+          const location = dlRes2.headers.get("location");
+          if (location) {
+            const videoRes = await fetch(location);
+            if (videoRes.ok) {
+              const { writeFile, mkdir } = await import("fs/promises");
+              const { dirname } = await import("path");
+              const buffer = Buffer.from(await videoRes.arrayBuffer());
+              await mkdir(dirname(opts.output), { recursive: true });
+              await writeFile(opts.output, buffer);
+              const contentType = videoRes.headers.get("content-type") || "video/mp4";
+              if (isJsonMode(media)) {
+                jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
+                return;
+              }
+              console.log(`Cinematic video saved to ${opts.output} (${buffer.length} bytes)`);
+              return;
+            }
           }
         }
 
@@ -682,7 +713,11 @@ export function registerMediaCommand(program: Command): void {
     .action(
       async (opts: { jobId: string; variant?: string }) => {
         const body: Record<string, unknown> = { jobId: opts.jobId };
-        if (opts.variant) body.variant = parseInt(opts.variant, 10);
+        if (opts.variant) {
+          const v = parseInt(opts.variant, 10);
+          if (Number.isNaN(v)) throw new Error("--variant must be a number (1 or 2)");
+          body.variant = v;
+        }
 
         const resp = (await apiPost(
           "/media-gen/avatars/confirm",

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -581,8 +581,8 @@ export function registerMediaCommand(program: Command): void {
           ethnicity: opts.ethnicity,
           outfit: opts.outfit,
           background: opts.background,
+          isPortrait: opts.portrait,
         };
-        if (!opts.portrait) body.isPortrait = false;
         if (opts.audioMediaId) body.audioMediaId = opts.audioMediaId;
 
         const resp = (await apiPost(

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -493,6 +493,305 @@ export function registerMediaCommand(program: Command): void {
     });
 
   // ════════════════════════════════════════════════════════════════════
+  //  Cinematic Video
+  // ════════════════════════════════════════════════════════════════════
+
+  media
+    .command("cinematic-create")
+    .description("Create a cinematic video from a text prompt.")
+    .requiredOption("--prompt <prompt>", "Text prompt describing the video")
+    .option("--name <name>", "Name for the video (auto-generated if omitted)")
+    .option("--aspect-ratio <aspectRatio>", "Aspect ratio: 16:9, 9:16, 1:1")
+    .option("--duration <seconds>", "Duration in seconds (4-8)")
+    .option("--resolution <resolution>", "Resolution: 720p, 1080p")
+    .option("--enhance-prompt", "Enhance the prompt with AI")
+    .option("--generate-audio", "Generate audio for the video")
+    .option("--negative-prompt <negativePrompt>", "Negative prompt")
+    .option("--sample-count <count>", "Number of samples (1-4)")
+    .option("--first-frame-media-id <mediaId>", "First frame image media ID")
+    .option("--last-frame-media-id <mediaId>", "Last frame image media ID")
+    .option("--reference-media-ids <ids>", "Comma-separated reference image media IDs (max 3)")
+    .option("--wait", "Poll until generation completes")
+    .option("-o, --output <path>", "Download video to this path when done (implies --wait)")
+    .action(
+      async (opts: {
+        prompt: string;
+        name?: string;
+        aspectRatio?: string;
+        duration?: string;
+        resolution?: string;
+        enhancePrompt?: boolean;
+        generateAudio?: boolean;
+        negativePrompt?: string;
+        sampleCount?: string;
+        firstFrameMediaId?: string;
+        lastFrameMediaId?: string;
+        referenceMediaIds?: string;
+        wait?: boolean;
+        output?: string;
+      }) => {
+        const shouldWait = opts.wait || !!opts.output;
+        const autoName = opts.name || `cinematic-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`;
+        const body: Record<string, unknown> = {
+          name: autoName,
+          prompt: opts.prompt,
+        };
+        if (opts.aspectRatio) body.aspectRatio = opts.aspectRatio;
+        if (opts.duration) body.durationSeconds = parseInt(opts.duration, 10);
+        if (opts.resolution) body.resolution = opts.resolution;
+        if (opts.enhancePrompt) body.enhancePrompt = true;
+        if (opts.generateAudio) body.generateAudio = true;
+        if (opts.negativePrompt) body.negativePrompt = opts.negativePrompt;
+        if (opts.sampleCount) body.sampleCount = parseInt(opts.sampleCount, 10);
+        if (opts.firstFrameMediaId) body.firstFrameImageMediaId = opts.firstFrameMediaId;
+        if (opts.lastFrameMediaId) body.lastFrameImageMediaId = opts.lastFrameMediaId;
+        if (opts.referenceMediaIds) body.referenceImageMediaIds = opts.referenceMediaIds.split(",").map((s) => s.trim());
+
+        const resp = (await apiPost(
+          "/media-gen/videos/cinematic",
+          body,
+        )) as Record<string, unknown>;
+        let data = unwrapResp(resp) as Record<string, unknown>;
+        const videoId = data.id || data.videoId;
+
+        if (shouldWait && videoId) {
+          console.log(`Cinematic video ${videoId} queued — polling for completion…`);
+          data = await pollStatus(
+            `/media-gen/videos/${videoId}/status`,
+            ["inference_complete", "inference_failed"],
+          );
+        }
+
+        // Download video to file if -o specified
+        if (opts.output && videoId && data.status === "inference_complete") {
+          const token = await getValidToken();
+          const dlUrl = `${BASE_URL}/media-gen/videos/${videoId}/download`;
+          const dlRes = await fetch(dlUrl, {
+            headers: { Authorization: `Bearer ${token}` },
+            redirect: "follow",
+          });
+          if (dlRes.ok) {
+            const { writeFile, mkdir } = await import("fs/promises");
+            const { dirname } = await import("path");
+            const buffer = Buffer.from(await dlRes.arrayBuffer());
+            await mkdir(dirname(opts.output), { recursive: true });
+            await writeFile(opts.output, buffer);
+            const contentType = dlRes.headers.get("content-type") || "video/mp4";
+            if (isJsonMode(media)) {
+              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
+              return;
+            }
+            console.log(`Cinematic video saved to ${opts.output} (${buffer.length} bytes)`);
+            return;
+          }
+        }
+
+        if (isJsonMode(media)) {
+          jsonOut(data);
+          return;
+        }
+
+        const status = data.status || "queued";
+        console.log(
+          `Cinematic video created!\n` +
+            `  ID:     ${videoId}\n` +
+            `  Status: ${status}`,
+        );
+        if (status === "inference_complete") {
+          console.log(`  Download: gobi media video-download ${videoId}`);
+        }
+      },
+    );
+
+  // ════════════════════════════════════════════════════════════════════
+  //  Custom Avatars
+  // ════════════════════════════════════════════════════════════════════
+
+  media
+    .command("avatar-design")
+    .description("Start a design-your-avatar job.")
+    .requiredOption("--name <name>", "Name for the avatar")
+    .requiredOption("--gender <gender>", "Gender for the avatar design")
+    .requiredOption("--age <age>", "Age range for the avatar")
+    .requiredOption("--ethnicity <ethnicity>", "Ethnicity for the avatar")
+    .requiredOption("--outfit <outfit>", "Outfit description")
+    .requiredOption("--background <background>", "Background description")
+    .option("--no-portrait", "Generate full-body instead of portrait")
+    .option("--audio-media-id <mediaId>", "Custom voice audio media ID")
+    .option("--wait", "Poll until variants are ready")
+    .action(
+      async (opts: {
+        name: string;
+        gender: string;
+        age: string;
+        ethnicity: string;
+        outfit: string;
+        background: string;
+        portrait: boolean;
+        audioMediaId?: string;
+        wait?: boolean;
+      }) => {
+        const body: Record<string, unknown> = {
+          name: opts.name,
+          gender: opts.gender,
+          age: opts.age,
+          ethnicity: opts.ethnicity,
+          outfit: opts.outfit,
+          background: opts.background,
+        };
+        if (!opts.portrait) body.isPortrait = false;
+        if (opts.audioMediaId) body.audioMediaId = opts.audioMediaId;
+
+        const resp = (await apiPost(
+          "/media-gen/avatars/design",
+          body,
+        )) as Record<string, unknown>;
+        let data = unwrapResp(resp) as Record<string, unknown>;
+        const jobId = data.jobId || data.id;
+
+        if (opts.wait && jobId) {
+          console.log(`Avatar design job ${jobId} — polling for completion…`);
+          data = await pollStatus(
+            `/media-gen/avatars/jobs/${jobId}/status`,
+            ["variants_ready", "complete", "failed"],
+          );
+        }
+
+        if (isJsonMode(media)) {
+          jsonOut(data);
+          return;
+        }
+
+        const status = data.status || "queued";
+        console.log(
+          `Avatar design started!\n` +
+            `  Job ID: ${jobId}\n` +
+            `  Status: ${status}`,
+        );
+        if (status === "variants_ready") {
+          console.log(`  Confirm: gobi media avatar-confirm --job-id ${jobId}`);
+        }
+      },
+    );
+
+  media
+    .command("avatar-confirm")
+    .description("Confirm avatar variant(s) after design.")
+    .requiredOption("--job-id <jobId>", "Job ID from avatar-design")
+    .option("--variant <variant>", "Variant to confirm (1 or 2); omit to confirm both")
+    .action(
+      async (opts: { jobId: string; variant?: string }) => {
+        const body: Record<string, unknown> = { jobId: opts.jobId };
+        if (opts.variant) body.variant = parseInt(opts.variant, 10);
+
+        const resp = (await apiPost(
+          "/media-gen/avatars/confirm",
+          body,
+        )) as Record<string, unknown>;
+        const data = unwrapResp(resp) as Record<string, unknown>;
+
+        if (isJsonMode(media)) {
+          jsonOut(data);
+          return;
+        }
+
+        const avatarId = data.avatarId || data.id;
+        console.log(
+          `Avatar confirmed!\n` +
+            `  Avatar ID: ${avatarId || JSON.stringify(data)}`,
+        );
+      },
+    );
+
+  media
+    .command("avatar-from-selfie")
+    .description("Create an avatar from a selfie (instant or enhanced with prompt).")
+    .requiredOption("--name <name>", "Name for the avatar")
+    .requiredOption("--photo-media-id <mediaId>", "Selfie photo media ID")
+    .option("--prompt <prompt>", "Enhancement prompt (triggers async enhance flow)")
+    .option("--audio-media-id <mediaId>", "Custom voice audio media ID")
+    .option("--wait", "Poll until job completes (only for enhance flow)")
+    .action(
+      async (opts: {
+        name: string;
+        photoMediaId: string;
+        prompt?: string;
+        audioMediaId?: string;
+        wait?: boolean;
+      }) => {
+        const body: Record<string, unknown> = {
+          name: opts.name,
+          photoMediaId: opts.photoMediaId,
+        };
+        if (opts.prompt) body.prompt = opts.prompt;
+        if (opts.audioMediaId) body.audioMediaId = opts.audioMediaId;
+
+        const resp = (await apiPost(
+          "/media-gen/avatars/from-selfie",
+          body,
+        )) as Record<string, unknown>;
+        let data = unwrapResp(resp) as Record<string, unknown>;
+        const jobId = data.jobId || data.id;
+
+        // Enhance flow is async — poll if --wait
+        if (opts.wait && opts.prompt && jobId) {
+          console.log(`Avatar enhance job ${jobId} — polling for completion…`);
+          data = await pollStatus(
+            `/media-gen/avatars/jobs/${jobId}/status`,
+            ["variants_ready", "complete", "failed"],
+          );
+        }
+
+        if (isJsonMode(media)) {
+          jsonOut(data);
+          return;
+        }
+
+        if (opts.prompt) {
+          const status = data.status || "queued";
+          console.log(
+            `Avatar enhance started!\n` +
+              `  Job ID: ${jobId}\n` +
+              `  Status: ${status}`,
+          );
+        } else {
+          const avatarId = data.avatarId || data.id;
+          console.log(
+            `Avatar created from selfie!\n` +
+              `  Avatar ID: ${avatarId || JSON.stringify(data)}`,
+          );
+        }
+      },
+    );
+
+  media
+    .command("avatar-job-status <jobId>")
+    .description("Check avatar job status.")
+    .option("--wait", "Poll until a terminal state is reached")
+    .action(async (jobId: string, opts: { wait?: boolean }) => {
+      let data: Record<string, unknown>;
+
+      if (opts.wait) {
+        data = await pollStatus(
+          `/media-gen/avatars/jobs/${jobId}/status`,
+          ["variants_ready", "complete", "failed"],
+        );
+      } else {
+        const resp = (await apiGet(
+          `/media-gen/avatars/jobs/${jobId}/status`,
+        )) as Record<string, unknown>;
+        data = unwrapResp(resp) as Record<string, unknown>;
+      }
+
+      if (isJsonMode(media)) {
+        jsonOut(data);
+        return;
+      }
+
+      console.log(`Avatar job ${jobId} — status: ${data.status || "unknown"}`);
+    });
+
+  // ════════════════════════════════════════════════════════════════════
   //  Images
   // ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Linear Issue
https://linear.app/gobi/issue/GOBI-257

## Summary
- Add 5 new subcommands to `gobi media`: `cinematic-create`, `avatar-design`, `avatar-confirm`, `avatar-from-selfie`, `avatar-job-status`
- Full CLI workflow support for cinematic video generation and custom avatar creation

## Changes
- `src/commands/media.ts`: 5 new subcommands with --wait polling, --json output, auto-name generation

## Test Plan
- [ ] Verify `gobi media cinematic-create --prompt "..." --wait` creates and polls cinematic video
- [ ] Verify `gobi media avatar-design --name ... --gender ... --wait` starts design job and polls
- [ ] Verify `gobi media avatar-confirm --job-id ...` confirms variants
- [ ] Verify `gobi media avatar-from-selfie --name ... --photo-media-id ...` creates instant avatar
- [ ] Verify `gobi media avatar-from-selfie --name ... --photo-media-id ... --prompt "..." --wait` uses enhance flow
- [ ] Verify `gobi media avatar-job-status <jobId> --wait` polls status
- [ ] Verify all commands work with `--json` flag
- [ ] Verify `gobi media cinematic-create --prompt "..." -o video.mp4` downloads on completion