### PR TITLE
Release 0.9.11: media refactor and homepage skill updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "0.9.9",
+  "version": "0.9.8",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "0.9.9",
+      "version": "0.9.8",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "0.9.9",
+  "version": "0.9.8",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "author": {
     "name": "gobi-ai"
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: patch
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -22,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -34,109 +24,16 @@ jobs:
       - run: npm run build
       - run: npm test
 
-      # Step 1 — Bump version in package.json (also creates git tag)
-      - name: Bump version
-        id: version
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ inputs.bump }} --no-git-tag-version
-          VERSION=$(node -p 'require("./package.json").version')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      # Step 2 — Update marketplace.json and plugin.json to match
-      - name: Update marketplace & plugin versions
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          # Update marketplace.json top-level and plugin version
-          node -e "
-            const fs = require('fs');
-            const m = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json','utf8'));
-            m.version = '${VERSION}';
-            m.plugins.forEach(p => p.version = '${VERSION}');
-            fs.writeFileSync('.claude-plugin/marketplace.json', JSON.stringify(m, null, 2) + '\n');
-          "
-
-      # Step 3 — Regenerate skill docs
-      - name: Regenerate skill docs
-        run: npx tsx scripts/generate-skill-docs.ts
-
-      # Step 4 — Commit, tag, and push
-      - name: Commit and tag
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git add package.json package-lock.json .claude-plugin/ skills/
-          git commit -m "Bump version to ${VERSION}"
-          git tag "v${VERSION}"
-          git push
-          git push --tags
-
-      # Step 5 — Build release tarball
       - name: Pack tarball
         run: npm pack
 
-      # Step 6 — Create GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
           files: "*.tgz"
 
-      # Step 7 — Publish to npm
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # Step 8 — Update Homebrew formula
-      - name: Update Homebrew formula
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-
-          # Wait for npm registry to be available
-          for i in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz")
-            if [ "$STATUS" = "200" ]; then break; fi
-            echo "Waiting for npm registry (attempt $i)..."
-            sleep 15
-          done
-
-          SHA256=$(curl -sL "https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz" | shasum -a 256 | cut -d' ' -f1)
-          URL="https://registry.npmjs.org/@gobi-ai/cli/-/cli-${VERSION}.tgz"
-
-          node -e "
-            const fs = require('fs');
-            const formula = [
-              'class Gobi < Formula',
-              '  desc \"CLI client for the Gobi collaborative knowledge platform\"',
-              '  homepage \"https://github.com/gobi-ai/gobi-cli\"',
-              '  url \"${URL}\"',
-              '  sha256 \"${SHA256}\"',
-              '  license \"MIT\"',
-              '',
-              '  depends_on \"node\"',
-              '',
-              '  def install',
-              '    system \"npm\", \"install\", *std_npm_args',
-              '    bin.install_symlink Dir[\"#\{libexec\}/bin/*\"]',
-              '  end',
-              '',
-              '  test do',
-              '    assert_match version.to_s, shell_output(\"#\{bin\}/gobi --version\")',
-              '  end',
-              'end',
-              '',
-            ].join('\n');
-            fs.writeFileSync('/tmp/gobi-formula.rb', formula);
-          "
-
-          CONTENT=$(base64 -w0 < /tmp/gobi-formula.rb)
-          FILE_SHA=$(gh api repos/gobi-ai/homebrew-tap/contents/Formula/gobi.rb --jq .sha)
-          gh api repos/gobi-ai/homebrew-tap/contents/Formula/gobi.rb \
-            -X PUT \
-            -f message="Update gobi formula to v${VERSION}" \
-            -f content="${CONTENT}" \
-            -f sha="${FILE_SHA}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.9",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "0.9.9",
+      "version": "0.9.8",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "0.9.9",
+  "version": "0.9.8",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -165,6 +165,164 @@ function resolveWikiImages(md) {
 const html = marked.parse(resolveWikiImages(update.content));
 ```
 
+**Open links in a new tab.** The homepage runs in a sandboxed iframe — clicking a rendered link replaces the iframe with the external page. Override the renderer so every `<a>` opens in a new tab:
+
+```js
+const renderer = new marked.Renderer();
+const origLink = renderer.link.bind(renderer);
+renderer.link = (href, title, text) =>
+  origLink(href, title, text).replace('<a ', '<a target="_blank" rel="noopener" ');
+marked.setOptions({ renderer });
+```
+
+**Plain-text previews.** For BU list cards, render a truncated preview with `escapeHtml(content.substring(0, 200))` — don't run markdown on a random substring, it produces broken HTML. Use `marked.parse(resolveWikiImages(content))` only for the full expanded view. Same for chat: `marked.parse(content)` for assistant messages, `escapeHtml(content)` for human messages.
+
+---
+
+## Polished Homepage Patterns
+
+Optional patterns that go beyond the minimal example. Pick the ones you need.
+
+### Design tokens
+
+Centralize colors and spacing in CSS custom properties so restyling is a one-line change:
+
+```css
+:root {
+  --bg: #000;
+  --fg: #fff;
+  --accent: #ccff00;
+  --grey-900: #111;   /* card bg */
+  --grey-700: #2a2a2a; /* borders */
+  --grey-500: #606060; /* secondary text */
+  --border: 2px;
+  --transition: 0.15s ease;
+}
+```
+
+Pair with Google Fonts (e.g. Space Grotesk for headings, IBM Plex Mono for meta, Inter for body) via CDN `<link>`.
+
+### Knowledge Graph from BU topics
+
+Brain updates carry a `topics` array. Treat each topic as a node and any two topics co-occurring in the same BU as an edge — you get a force-directed graph of the vault's themes for free. Use [d3](https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js).
+
+```js
+// Separate data-building from rendering so the same graph can be drawn at multiple sizes.
+function buildGraphData(updates) {
+  const counts = new Map();     // name → frequency
+  const edges  = new Map();     // "a|b" → weight
+  for (const u of updates) {
+    const names = (u.topics || []).map(t => t.name);
+    for (const n of names) counts.set(n, (counts.get(n) || 0) + 1);
+    for (let i = 0; i < names.length; i++)
+      for (let j = i + 1; j < names.length; j++) {
+        const key = [names[i], names[j]].sort().join('|');
+        edges.set(key, (edges.get(key) || 0) + 1);
+      }
+  }
+  // Top 20 by frequency, then drop orphans (nodes with no surviving edges).
+  const top = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20).map(([n]) => n);
+  const keep = new Set(top);
+  const links = [...edges].flatMap(([k, w]) => {
+    const [a, b] = k.split('|');
+    return keep.has(a) && keep.has(b) ? [{ source: a, target: b, weight: w }] : [];
+  });
+  const connected = new Set(links.flatMap(l => [l.source, l.target]));
+  const nodes = top.filter(n => connected.has(n)).map(n => ({ id: n, count: counts.get(n) }));
+  return { nodes, links };
+}
+
+function drawGraph(containerId, w, h, data, opts = {}) {
+  const { nodeRange = [4, 16], fontSize = '9px', distance = 60, charge = -80 } = opts;
+  const max = Math.max(...data.nodes.map(n => n.count), 1);
+  const r = d3.scaleSqrt().domain([1, max]).range(nodeRange);
+  const svg = d3.select('#' + containerId).append('svg').attr('width', w).attr('height', h);
+  // ... standard d3.forceSimulation with link/charge/center, then clamp in tick:
+  //   node.attr('cx', d => d.x = Math.max(20, Math.min(w - 20, d.x)))
+  //   node.attr('cy', d => d.y = Math.max(20, Math.min(h - 20, d.y)))
+  // Node fill: accent with opacity 0.3 + 0.7 * (count/max).
+  // Call d3.drag() on nodes so visitors can rearrange the graph.
+}
+```
+
+Tips:
+- **Enrich the data.** One page of 8 BUs makes a sparse graph. Paginate 3–4 times (cap at ~32 BUs) before building.
+- **Cache the built data** in a module-level variable so the full-screen overlay can reuse it without refetching.
+- **Mini vs full presets.** Pass different `opts` — e.g. mini `{nodeRange:[4,16], fontSize:'9px', distance:60, charge:-80}`, full `{nodeRange:[8,32], fontSize:'12px', distance:120, charge:-200}`.
+- Run a **separate simulation** for the full-scale instance — copy the nodes/links rather than sharing references, otherwise both graphs fight over the same positions.
+
+### Full-screen overlay
+
+Useful for expanding the K-Graph (or any small component) into a focused view:
+
+```js
+function openOverlay(renderInto) {
+  const o = document.createElement('div');
+  o.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.95);z-index:1000';
+  o.innerHTML = '<button id="x" style="position:absolute;top:16px;right:16px">CLOSE</button><div id="body" style="width:100%;height:100%"></div>';
+  document.body.appendChild(o);
+  document.body.style.overflow = 'hidden';
+  const close = () => { o.remove(); document.body.style.overflow = ''; document.removeEventListener('keydown', onKey); };
+  const onKey = e => { if (e.key === 'Escape') close(); };
+  o.querySelector('#x').onclick = close;
+  document.addEventListener('keydown', onKey);
+  renderInto(o.querySelector('#body'));
+}
+```
+
+Always restore `body.overflow` on close, and always remove the `keydown` listener.
+
+### Brain update card — preview/full toggle
+
+Show a truncated card that expands in place on click:
+
+```js
+card.onclick = (event) => {
+  // Link click guard — don't toggle when the user clicked a link inside the card.
+  if (event.target.closest('a')) return;
+  card.classList.toggle('expanded');
+  card.querySelector('.body').innerHTML = card.classList.contains('expanded')
+    ? marked.parse(resolveWikiImages(update.content))
+    : escapeHtml(update.content.substring(0, 200));
+};
+```
+
+### Chat suggestion chips
+
+Empty chat looks dead. Show clickable prompt chips until the first message is sent:
+
+```js
+const prompts = ['What is this brain about?', 'Summarize the latest update', 'What topics come up most?'];
+chips.innerHTML = prompts.map(p => `<button class="chip">${escapeHtml(p)}</button>`).join('');
+chips.querySelectorAll('.chip').forEach((btn, i) => {
+  btn.onclick = () => { input.value = prompts[i]; chips.remove(); input.focus(); };
+});
+```
+
+### Footer — POWERED BY GOBI
+
+Link back to the vault's public page with `?og=1` so the link preview uses the vault's Open Graph metadata:
+
+```html
+<footer>
+  <a href="https://www.gobispace.com/@${gobi.vault.slug}?og=1" target="_blank" rel="noopener">
+    POWERED BY GOBI
+  </a>
+</footer>
+```
+
+### Mobile responsive
+
+Single breakpoint at `768px` is enough for most homepages:
+
+```css
+@media (max-width: 768px) {
+  .hero-grid, .updates-grid { grid-template-columns: 1fr; }
+  .hero-content { flex-direction: column; }
+  .btn { width: 100%; }
+}
+```
+
 ---
 
 ## Complete Example

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -67,9 +67,14 @@ gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>"
 
 The `-o` flag implies `--wait` and downloads the video when done.
 
-To use a custom image as the **background** of a video, upload it via `upload-init` / `upload-finalize`, then pass the mediaId as `--background-media-id`:
+To use a custom image as the **background** of a video, upload it first, then pass the mediaId as `--background-media-id`:
 
 ```bash
+# 1. Upload the image
+gobi --json media upload media/bg.png
+# Returns { mediaId: "<MEDIA_ID>" }
+
+# 2. Create video with custom background
 gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>" --script "<SCRIPT>" --background-media-id "<MEDIA_ID>" -o media/<NAME>.mp4
 ```
 
@@ -105,7 +110,7 @@ gobi --json media avatar-confirm --job-id "<JOB_ID>"
 gobi --json media avatar-from-selfie --name "<NAME>" --photo-media-id "<MEDIA_ID>"
 ```
 
-Upload the selfie first via `upload-init` / `upload-finalize` to get the media ID.
+Upload the selfie first to get the media ID: `gobi --json media upload media/selfie.png`
 
 ### 3. From a selfie (enhanced with prompt)
 
@@ -131,8 +136,7 @@ Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs. Always use `
 
 ### Upload
 
-- `gobi media upload-init` — Get a presigned upload URL for a media file.
-- `gobi media upload-finalize` — Confirm that a media upload is complete.
+- `gobi media upload <file>` — Upload a local file and return its media ID. Content type is auto-detected.
 
 ### Avatars & Voices
 

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -67,15 +67,10 @@ gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>"
 
 The `-o` flag implies `--wait` and downloads the video when done.
 
-To use a custom image as the **background** of a video, upload it first, then pass the mediaId as `--background-media-id`:
+To use a custom image as the **background** of a video, pass it directly as `--background <file>` (auto-uploaded):
 
 ```bash
-# 1. Upload the image
-gobi --json media upload media/bg.png
-# Returns { mediaId: "<MEDIA_ID>" }
-
-# 2. Create video with custom background
-gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>" --script "<SCRIPT>" --background-media-id "<MEDIA_ID>" -o media/<NAME>.mp4
+gobi --json media video-create --avatar-id "<AVATAR_ID>" --voice-id "<VOICE_ID>" --script "<SCRIPT>" --background media/bg.png -o media/<NAME>.mp4
 ```
 
 ## Typical Workflow (Cinematic Video)
@@ -86,7 +81,17 @@ Generate a cinematic video from a text prompt (no avatar needed):
 gobi --json media cinematic-create --prompt "<PROMPT>" --aspect-ratio "<RATIO>" -o media/<NAME>.mp4
 ```
 
-Options: `--duration <4-8>`, `--resolution <720p|1080p>`, `--enhance-prompt`, `--generate-audio`, `--negative-prompt`, `--sample-count <1-4>`, `--first-frame-media-id`, `--last-frame-media-id`, `--reference-media-ids`.
+Options: `--duration <4-8>`, `--resolution <720p|1080p>`, `--enhance-prompt`, `--generate-audio`, `--negative-prompt`, `--sample-count <1-4>`, `--first-frame <file>`, `--last-frame <file>`, `--reference-images <files>`.
+
+## Typical Workflow (Image Editing)
+
+Edit an existing image with a prompt — single command:
+
+```bash
+gobi --json media image-edit --image media/source.png --prompt "<EDIT_INSTRUCTION>" -o media/<NAME>.png
+```
+
+All file arguments (`--image`, `--mask`, `--background`, `--photo`, `--audio`, `--reference-image`, `--first-frame`, `--last-frame`) accept local file paths and auto-upload them. No need to manually upload first.
 
 ## Custom Avatars
 
@@ -95,7 +100,7 @@ Three ways to create custom avatars:
 ### 1. Design from scratch
 
 ```bash
-gobi --json media avatar-design --name "<NAME>" --gender "<GENDER>" --age "<AGE>" --ethnicity "<ETHNICITY>" --outfit "<OUTFIT>" --background "<BACKGROUND>" --wait
+gobi --json media avatar-design --gender "<GENDER>" --age "<AGE>" --ethnicity "<ETHNICITY>" --outfit "<OUTFIT>" --background "<BACKGROUND>" --wait
 ```
 
 When `variants_ready`, confirm with:
@@ -107,15 +112,13 @@ gobi --json media avatar-confirm --job-id "<JOB_ID>"
 ### 2. From a selfie (instant)
 
 ```bash
-gobi --json media avatar-from-selfie --name "<NAME>" --photo-media-id "<MEDIA_ID>"
+gobi --json media avatar-from-selfie --photo media/selfie.png
 ```
-
-Upload the selfie first to get the media ID: `gobi --json media upload media/selfie.png`
 
 ### 3. From a selfie (enhanced with prompt)
 
 ```bash
-gobi --json media avatar-from-selfie --name "<NAME>" --photo-media-id "<MEDIA_ID>" --prompt "<ENHANCEMENT>" --wait
+gobi --json media avatar-from-selfie --photo media/selfie.png --prompt "<ENHANCEMENT>" --wait
 ```
 
 Check any avatar job status with:

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -168,6 +168,8 @@ Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs. Always use `
 - `gobi media image-edit` — Edit an existing image with a prompt (image-to-image).
 - `gobi media image-inpaint` — Inpaint an image region using a mask.
 - `gobi media image-status` — Check image generation job status.
+- `gobi media image-download` — Download a generated image.
+- `gobi media image-status` — Check image generation job status.
 
 ## Reference Documentation
 

--- a/skills/gobi-media/references/media.md
+++ b/skills/gobi-media/references/media.md
@@ -9,7 +9,7 @@ Options:
   -h, --help                           display help for command
 
 Commands:
-  upload [options] <file>              Upload a local file and return its media ID.
+  upload <file>                        Upload a local file and return its media ID.
   avatars                              List available avatars.
   voices                               List available voices.
   video-create [options]               Create an avatar video generation job.
@@ -38,8 +38,7 @@ Usage: gobi media upload [options] <file>
 Upload a local file and return its media ID.
 
 Options:
-  --content-type <contentType>  MIME type override (auto-detected from extension if omitted)
-  -h, --help                    display help for command
+  -h, --help  display help for command
 ```
 
 ## avatars
@@ -72,14 +71,14 @@ Usage: gobi media video-create [options]
 Create an avatar video generation job.
 
 Options:
-  --name <name>                              Name for the video (auto-generated if omitted)
-  --avatar-id <avatarId>                     Avatar to use
-  --voice-id <voiceId>                       Voice to use
-  --script <script>                          Script for the avatar to read
-  --background-media-id <backgroundMediaId>  Background media ID (from upload)
-  --wait                                     Poll until generation completes
-  -o, --output <path>                        Download video to this path when done (implies --wait)
-  -h, --help                                 display help for command
+  --name <name>           Name for the video (auto-generated if omitted)
+  --avatar-id <avatarId>  Avatar to use
+  --voice-id <voiceId>    Voice to use
+  --script <script>       Script for the avatar to read
+  --background <file>     Background image file (auto-uploaded)
+  --wait                  Poll until generation completes
+  -o, --output <path>     Download video to this path when done (implies --wait)
+  -h, --help              display help for command
 ```
 
 ## video-list
@@ -146,9 +145,9 @@ Options:
   --generate-audio                    Generate audio for the video
   --negative-prompt <negativePrompt>  Negative prompt
   --sample-count <count>              Number of samples (1-4)
-  --first-frame-media-id <mediaId>    First frame image media ID
-  --last-frame-media-id <mediaId>     Last frame image media ID
-  --reference-media-ids <ids>         Comma-separated reference image media IDs (max 3)
+  --first-frame <file>                First frame image file (auto-uploaded)
+  --last-frame <file>                 Last frame image file (auto-uploaded)
+  --reference-images <files>          Comma-separated reference image files (auto-uploaded, max 3)
   --wait                              Poll until generation completes
   -o, --output <path>                 Download video to this path when done (implies --wait)
   -h, --help                          display help for command
@@ -162,16 +161,16 @@ Usage: gobi media avatar-design [options]
 Start a design-your-avatar job.
 
 Options:
-  --name <name>               Name for the avatar (auto-generated if omitted)
-  --gender <gender>           Gender for the avatar design
-  --age <age>                 Age range for the avatar
-  --ethnicity <ethnicity>     Ethnicity for the avatar
-  --outfit <outfit>           Outfit description
-  --background <background>   Background description
-  --no-portrait               Generate full-body instead of portrait
-  --audio-media-id <mediaId>  Custom voice audio media ID
-  --wait                      Poll until variants are ready
-  -h, --help                  display help for command
+  --name <name>              Name for the avatar (auto-generated if omitted)
+  --gender <gender>          Gender for the avatar design
+  --age <age>                Age range for the avatar
+  --ethnicity <ethnicity>    Ethnicity for the avatar
+  --outfit <outfit>          Outfit description
+  --background <background>  Background description
+  --no-portrait              Generate full-body instead of portrait
+  --audio <file>             Custom voice audio file (auto-uploaded)
+  --wait                     Poll until variants are ready
+  -h, --help                 display help for command
 ```
 
 ## avatar-confirm
@@ -195,12 +194,12 @@ Usage: gobi media avatar-from-selfie [options]
 Create an avatar from a selfie (instant or enhanced with prompt).
 
 Options:
-  --name <name>               Name for the avatar (auto-generated if omitted)
-  --photo-media-id <mediaId>  Selfie photo media ID
-  --prompt <prompt>           Enhancement prompt (triggers async enhance flow)
-  --audio-media-id <mediaId>  Custom voice audio media ID
-  --wait                      Poll until job completes (only for enhance flow)
-  -h, --help                  display help for command
+  --name <name>      Name for the avatar (auto-generated if omitted)
+  --photo <file>     Selfie photo file (auto-uploaded)
+  --prompt <prompt>  Enhancement prompt (triggers async enhance flow)
+  --audio <file>     Custom voice audio file (auto-uploaded)
+  --wait             Poll until job completes (only for enhance flow)
+  -h, --help         display help for command
 ```
 
 ## avatar-job-status
@@ -223,16 +222,16 @@ Usage: gobi media image-generate [options]
 Generate an image from a text prompt. Types: image (default), thumbnail (YouTube-optimized), asset (logo/product). Aspect ratios: 1:1, 16:9, 9:16, 4:3, 3:4
 
 Options:
-  --prompt <prompt>                        Text prompt for image generation
-  --name <name>                            Name for the generated image (auto-generated from prompt if omitted)
-  --type <type>                            Generation type: image (default), thumbnail (YouTube-optimized), asset (logo/product)
-  --aspect-ratio <aspectRatio>             Aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4)
-  --negative-prompt <negativePrompt>       Negative prompt
-  --seed <seed>                            Random seed for reproducibility
-  --reference-media-id <referenceMediaId>  Reference image media ID
-  --wait                                   Poll until generation completes
-  -o, --output <path>                      Download image to this path when done (implies --wait)
-  -h, --help                               display help for command
+  --prompt <prompt>                   Text prompt for image generation
+  --name <name>                       Name for the generated image (auto-generated from prompt if omitted)
+  --type <type>                       Generation type: image (default), thumbnail (YouTube-optimized), asset (logo/product)
+  --aspect-ratio <aspectRatio>        Aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4)
+  --negative-prompt <negativePrompt>  Negative prompt
+  --seed <seed>                       Random seed for reproducibility
+  --reference-image <file>            Reference image file (auto-uploaded)
+  --wait                              Poll until generation completes
+  -o, --output <path>                 Download image to this path when done (implies --wait)
+  -h, --help                          display help for command
 ```
 
 ## image-edit
@@ -243,12 +242,12 @@ Usage: gobi media image-edit [options]
 Edit an existing image with a prompt (image-to-image).
 
 Options:
-  --media-id <mediaId>  Source image media ID
-  --prompt <prompt>     Edit instruction
-  --name <name>         Name for the edited image (auto-generated if omitted)
-  --wait                Poll until generation completes
-  -o, --output <path>   Download image to this path when done (implies --wait)
-  -h, --help            display help for command
+  --image <file>       Source image file (auto-uploaded)
+  --prompt <prompt>    Edit instruction
+  --name <name>        Name for the edited image (auto-generated if omitted)
+  --wait               Poll until generation completes
+  -o, --output <path>  Download image to this path when done (implies --wait)
+  -h, --help           display help for command
 ```
 
 ## image-inpaint
@@ -259,13 +258,13 @@ Usage: gobi media image-inpaint [options]
 Inpaint an image region using a mask.
 
 Options:
-  --media-id <mediaId>           Source image media ID
-  --mask-media-id <maskMediaId>  Mask image media ID
-  --prompt <prompt>              Inpainting prompt
-  --name <name>                  Name for the inpainted image (auto-generated if omitted)
-  --wait                         Poll until generation completes
-  -o, --output <path>            Download image to this path when done (implies --wait)
-  -h, --help                     display help for command
+  --image <file>       Source image file (auto-uploaded)
+  --mask <file>        Mask image file (auto-uploaded)
+  --prompt <prompt>    Inpainting prompt
+  --name <name>        Name for the inpainted image (auto-generated if omitted)
+  --wait               Poll until generation completes
+  -o, --output <path>  Download image to this path when done (implies --wait)
+  -h, --help           display help for command
 ```
 
 ## image-status

--- a/skills/gobi-media/references/media.md
+++ b/skills/gobi-media/references/media.md
@@ -9,8 +9,7 @@ Options:
   -h, --help                           display help for command
 
 Commands:
-  upload-init [options]                Get a presigned upload URL for a media file.
-  upload-finalize [options]            Confirm that a media upload is complete.
+  upload [options] <file>              Upload a local file and return its media ID.
   avatars                              List available avatars.
   voices                               List available voices.
   video-create [options]               Create an avatar video generation job.
@@ -31,30 +30,16 @@ Commands:
   help [command]                       display help for command
 ```
 
-## upload-init
+## upload
 
 ```
-Usage: gobi media upload-init [options]
+Usage: gobi media upload [options] <file>
 
-Get a presigned upload URL for a media file.
+Upload a local file and return its media ID.
 
 Options:
-  --file-name <fileName>        Name of the file to upload
-  --content-type <contentType>  MIME type (e.g. image/png, video/mp4)
-  --file-size <fileSize>        File size in bytes
+  --content-type <contentType>  MIME type override (auto-detected from extension if omitted)
   -h, --help                    display help for command
-```
-
-## upload-finalize
-
-```
-Usage: gobi media upload-finalize [options]
-
-Confirm that a media upload is complete.
-
-Options:
-  --media-id <mediaId>  Media ID from upload-init
-  -h, --help            display help for command
 ```
 
 ## avatars
@@ -177,7 +162,7 @@ Usage: gobi media avatar-design [options]
 Start a design-your-avatar job.
 
 Options:
-  --name <name>               Name for the avatar
+  --name <name>               Name for the avatar (auto-generated if omitted)
   --gender <gender>           Gender for the avatar design
   --age <age>                 Age range for the avatar
   --ethnicity <ethnicity>     Ethnicity for the avatar
@@ -210,7 +195,7 @@ Usage: gobi media avatar-from-selfie [options]
 Create an avatar from a selfie (instant or enhanced with prompt).
 
 Options:
-  --name <name>               Name for the avatar
+  --name <name>               Name for the avatar (auto-generated if omitted)
   --photo-media-id <mediaId>  Selfie photo media ID
   --prompt <prompt>           Enhancement prompt (triggers async enhance flow)
   --audio-media-id <mediaId>  Custom voice audio media ID
@@ -260,8 +245,9 @@ Edit an existing image with a prompt (image-to-image).
 Options:
   --media-id <mediaId>  Source image media ID
   --prompt <prompt>     Edit instruction
-  --name <name>         Name for the edited image
+  --name <name>         Name for the edited image (auto-generated if omitted)
   --wait                Poll until generation completes
+  -o, --output <path>   Download image to this path when done (implies --wait)
   -h, --help            display help for command
 ```
 
@@ -276,8 +262,9 @@ Options:
   --media-id <mediaId>           Source image media ID
   --mask-media-id <maskMediaId>  Mask image media ID
   --prompt <prompt>              Inpainting prompt
-  --name <name>                  Name for the inpainted image
+  --name <name>                  Name for the inpainted image (auto-generated if omitted)
   --wait                         Poll until generation completes
+  -o, --output <path>            Download image to this path when done (implies --wait)
   -h, --help                     display help for command
 ```
 

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -553,7 +553,7 @@ export function registerMediaCommand(program: Command): void {
   media
     .command("avatar-design")
     .description("Start a design-your-avatar job.")
-    .requiredOption("--name <name>", "Name for the avatar")
+    .option("--name <name>", "Name for the avatar (auto-generated if omitted)")
     .requiredOption("--gender <gender>", "Gender for the avatar design")
     .requiredOption("--age <age>", "Age range for the avatar")
     .requiredOption("--ethnicity <ethnicity>", "Ethnicity for the avatar")
@@ -564,7 +564,7 @@ export function registerMediaCommand(program: Command): void {
     .option("--wait", "Poll until variants are ready")
     .action(
       async (opts: {
-        name: string;
+        name?: string;
         gender: string;
         age: string;
         ethnicity: string;
@@ -575,7 +575,7 @@ export function registerMediaCommand(program: Command): void {
         wait?: boolean;
       }) => {
         const body: Record<string, unknown> = {
-          name: opts.name,
+          name: opts.name || `avatar-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`,
           gender: opts.gender,
           age: opts.age,
           ethnicity: opts.ethnicity,
@@ -653,21 +653,21 @@ export function registerMediaCommand(program: Command): void {
   media
     .command("avatar-from-selfie")
     .description("Create an avatar from a selfie (instant or enhanced with prompt).")
-    .requiredOption("--name <name>", "Name for the avatar")
+    .option("--name <name>", "Name for the avatar (auto-generated if omitted)")
     .requiredOption("--photo-media-id <mediaId>", "Selfie photo media ID")
     .option("--prompt <prompt>", "Enhancement prompt (triggers async enhance flow)")
     .option("--audio-media-id <mediaId>", "Custom voice audio media ID")
     .option("--wait", "Poll until job completes (only for enhance flow)")
     .action(
       async (opts: {
-        name: string;
+        name?: string;
         photoMediaId: string;
         prompt?: string;
         audioMediaId?: string;
         wait?: boolean;
       }) => {
         const body: Record<string, unknown> = {
-          name: opts.name,
+          name: opts.name || `avatar-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`,
           photoMediaId: opts.photoMediaId,
         };
         if (opts.prompt) body.prompt = opts.prompt;
@@ -857,19 +857,22 @@ export function registerMediaCommand(program: Command): void {
     .description("Edit an existing image with a prompt (image-to-image).")
     .requiredOption("--media-id <mediaId>", "Source image media ID")
     .requiredOption("--prompt <prompt>", "Edit instruction")
-    .requiredOption("--name <name>", "Name for the edited image")
+    .option("--name <name>", "Name for the edited image (auto-generated if omitted)")
     .option("--wait", "Poll until generation completes")
+    .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
     .action(
-      async (opts: { mediaId: string; prompt: string; name: string; wait?: boolean }) => {
+      async (opts: { mediaId: string; prompt: string; name?: string; wait?: boolean; output?: string }) => {
+        const shouldWait = opts.wait || !!opts.output;
+        const autoName = opts.name || opts.prompt.slice(0, 50).replace(/[^a-zA-Z0-9-_ ]/g, "").trim().replace(/\s+/g, "-");
         const resp = (await apiPost("/media-gen/images/edit", {
           mediaId: opts.mediaId,
           prompt: opts.prompt,
-          name: opts.name,
+          name: autoName,
         })) as Record<string, unknown>;
         let data = unwrapResp(resp) as Record<string, unknown>;
         const jobId = data.jobId || data.id;
 
-        if (opts.wait && jobId) {
+        if (shouldWait && jobId) {
           console.log(`Image edit job ${jobId} — polling for completion…`);
           data = await pollStatus(`/media-gen/images/${jobId}`, [
             "completed",
@@ -877,6 +880,30 @@ export function registerMediaCommand(program: Command): void {
             "inference_complete",
             "inference_failed",
           ]);
+        }
+
+        // Download image to file if -o specified
+        if (opts.output && jobId) {
+          const token = await getValidToken();
+          const query = "";
+          const url = `${BASE_URL}/media-gen/images/${jobId}/download${query}`;
+          const res = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (res.ok) {
+            const { writeFile, mkdir } = await import("fs/promises");
+            const { dirname } = await import("path");
+            const buffer = Buffer.from(await res.arrayBuffer());
+            await mkdir(dirname(opts.output), { recursive: true });
+            await writeFile(opts.output, buffer);
+            const contentType = res.headers.get("content-type") || "image/png";
+            if (isJsonMode(media)) {
+              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
+              return;
+            }
+            console.log(`Image saved to ${opts.output} (${buffer.length} bytes)`);
+            return;
+          }
         }
 
         if (isJsonMode(media)) {
@@ -902,26 +929,30 @@ export function registerMediaCommand(program: Command): void {
     .requiredOption("--media-id <mediaId>", "Source image media ID")
     .requiredOption("--mask-media-id <maskMediaId>", "Mask image media ID")
     .requiredOption("--prompt <prompt>", "Inpainting prompt")
-    .requiredOption("--name <name>", "Name for the inpainted image")
+    .option("--name <name>", "Name for the inpainted image (auto-generated if omitted)")
     .option("--wait", "Poll until generation completes")
+    .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
     .action(
       async (opts: {
         mediaId: string;
         maskMediaId: string;
         prompt: string;
-        name: string;
+        name?: string;
         wait?: boolean;
+        output?: string;
       }) => {
+        const shouldWait = opts.wait || !!opts.output;
+        const autoName = opts.name || opts.prompt.slice(0, 50).replace(/[^a-zA-Z0-9-_ ]/g, "").trim().replace(/\s+/g, "-");
         const resp = (await apiPost("/media-gen/images/inpaint", {
           mediaId: opts.mediaId,
           maskMediaId: opts.maskMediaId,
           prompt: opts.prompt,
-          name: opts.name,
+          name: autoName,
         })) as Record<string, unknown>;
         let data = unwrapResp(resp) as Record<string, unknown>;
         const jobId = data.jobId || data.id;
 
-        if (opts.wait && jobId) {
+        if (shouldWait && jobId) {
           console.log(`Inpaint job ${jobId} — polling for completion…`);
           data = await pollStatus(`/media-gen/images/${jobId}`, [
             "completed",
@@ -929,6 +960,29 @@ export function registerMediaCommand(program: Command): void {
             "inference_complete",
             "inference_failed",
           ]);
+        }
+
+        // Download image to file if -o specified
+        if (opts.output && jobId) {
+          const token = await getValidToken();
+          const url = `${BASE_URL}/media-gen/images/${jobId}/download`;
+          const res = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (res.ok) {
+            const { writeFile, mkdir } = await import("fs/promises");
+            const { dirname } = await import("path");
+            const buffer = Buffer.from(await res.arrayBuffer());
+            await mkdir(dirname(opts.output), { recursive: true });
+            await writeFile(opts.output, buffer);
+            const contentType = res.headers.get("content-type") || "image/png";
+            if (isJsonMode(media)) {
+              jsonOut({ ...data, filename: opts.output, contentType, size: buffer.length });
+              return;
+            }
+            console.log(`Image saved to ${opts.output} (${buffer.length} bytes)`);
+            return;
+          }
         }
 
         if (isJsonMode(media)) {

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -91,63 +91,72 @@ export function registerMediaCommand(program: Command): void {
   // ════════════════════════════════════════════════════════════════════
 
   media
-    .command("upload-init")
-    .description("Get a presigned upload URL for a media file.")
-    .requiredOption("--file-name <fileName>", "Name of the file to upload")
-    .requiredOption(
-      "--content-type <contentType>",
-      "MIME type (e.g. image/png, video/mp4)",
-    )
-    .option("--file-size <fileSize>", "File size in bytes")
+    .command("upload <file>")
+    .description("Upload a local file and return its media ID.")
+    .option("--content-type <contentType>", "MIME type override (auto-detected from extension if omitted)")
     .action(
-      async (opts: {
-        fileName: string;
-        contentType: string;
-        fileSize?: string;
-      }) => {
-        const body: Record<string, unknown> = {
-          fileName: opts.fileName,
-          contentType: opts.contentType,
+      async (file: string, opts: { contentType?: string }) => {
+        const { readFile, stat } = await import("fs/promises");
+        const { basename, extname } = await import("path");
+
+        // Read file
+        const buffer = await readFile(file);
+        const fileName = basename(file);
+        const fileSize = (await stat(file)).size;
+
+        // Auto-detect content type from extension
+        const ext = extname(file).toLowerCase();
+        const mimeMap: Record<string, string> = {
+          ".png": "image/png",
+          ".jpg": "image/jpeg",
+          ".jpeg": "image/jpeg",
+          ".webp": "image/webp",
+          ".gif": "image/gif",
+          ".mp4": "video/mp4",
+          ".mov": "video/quicktime",
+          ".mp3": "audio/mpeg",
+          ".wav": "audio/wav",
         };
-        if (opts.fileSize) body.fileSize = parseInt(opts.fileSize, 10);
-        const resp = (await apiPost(
-          "/media-gen/media/initialize",
-          body,
-        )) as Record<string, unknown>;
-        const data = unwrapResp(resp) as Record<string, unknown>;
+        const contentType = opts.contentType || mimeMap[ext] || "application/octet-stream";
+
+        // Step 1: Initialize upload
+        const initResp = (await apiPost("/media-gen/media/initialize", {
+          fileName,
+          contentType,
+          fileSize,
+        })) as Record<string, unknown>;
+        const initData = unwrapResp(initResp) as Record<string, unknown>;
+        const mediaId = initData.mediaId as string;
+        const uploadUrl = initData.uploadUrl as string;
+
+        if (!mediaId || !uploadUrl) {
+          throw new Error("Upload initialization failed: missing mediaId or uploadUrl");
+        }
+
+        // Step 2: PUT file to presigned URL
+        const putRes = await fetch(uploadUrl, {
+          method: "PUT",
+          headers: { "Content-Type": contentType },
+          body: buffer,
+        });
+        if (!putRes.ok) {
+          throw new Error(`Upload failed: ${putRes.status} ${await putRes.text()}`);
+        }
+
+        // Step 3: Finalize
+        const finalResp = (await apiPost("/media-gen/media/finalize", {
+          mediaId,
+        })) as Record<string, unknown>;
+        const finalData = unwrapResp(finalResp) as Record<string, unknown>;
 
         if (isJsonMode(media)) {
-          jsonOut(data);
+          jsonOut({ mediaId, ...finalData });
           return;
         }
 
-        console.log(
-          `Upload initialized!\n` +
-            `  Media ID:   ${data.mediaId}\n` +
-            `  Upload URL: ${data.uploadUrl}\n\n` +
-            `PUT your file to the upload URL, then run:\n` +
-            `  gobi media upload-finalize --media-id ${data.mediaId}`,
-        );
+        console.log(`Uploaded ${fileName} (${fileSize} bytes)\n  Media ID: ${mediaId}`);
       },
     );
-
-  media
-    .command("upload-finalize")
-    .description("Confirm that a media upload is complete.")
-    .requiredOption("--media-id <mediaId>", "Media ID from upload-init")
-    .action(async (opts: { mediaId: string }) => {
-      const resp = (await apiPost("/media-gen/media/finalize", {
-        mediaId: opts.mediaId,
-      })) as Record<string, unknown>;
-      const data = unwrapResp(resp) as Record<string, unknown>;
-
-      if (isJsonMode(media)) {
-        jsonOut(data);
-        return;
-      }
-
-      console.log(`Upload finalized for media ${opts.mediaId}.`);
-    });
 
   // ════════════════════════════════════════════════════════════════════
   //  Avatars & Voices

--- a/src/commands/media.ts
+++ b/src/commands/media.ts
@@ -73,6 +73,51 @@ async function downloadVideoToFile(
   return { contentType: ct || "video/mp4", size: buffer.length };
 }
 
+const MIME_MAP: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+};
+
+/**
+ * Upload a local file and return its media ID.
+ * Handles init → PUT → finalize in one call.
+ */
+async function uploadFile(filePath: string): Promise<string> {
+  const { readFile, stat } = await import("fs/promises");
+  const { basename, extname } = await import("path");
+
+  const buffer = await readFile(filePath);
+  const fileName = basename(filePath);
+  const fileSize = (await stat(filePath)).size;
+  const ext = extname(filePath).toLowerCase();
+  const contentType = MIME_MAP[ext] || "application/octet-stream";
+
+  const initResp = (await apiPost("/media-gen/media/initialize", {
+    fileName, contentType, fileSize,
+  })) as Record<string, unknown>;
+  const initData = unwrapResp(initResp) as Record<string, unknown>;
+  const mediaId = initData.mediaId as string;
+  const uploadUrl = initData.uploadUrl as string;
+  if (!mediaId || !uploadUrl) throw new Error("Upload init failed: missing mediaId or uploadUrl");
+
+  const putRes = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: buffer,
+  });
+  if (!putRes.ok) throw new Error(`Upload PUT failed: ${putRes.status}`);
+
+  await apiPost("/media-gen/media/finalize", { mediaId });
+  return mediaId;
+}
+
 function extractImageUrl(data: Record<string, unknown>): string | undefined {
   return (data.downloadUrl || data.download_url || data.url) as
     | string
@@ -93,68 +138,14 @@ export function registerMediaCommand(program: Command): void {
   media
     .command("upload <file>")
     .description("Upload a local file and return its media ID.")
-    .option("--content-type <contentType>", "MIME type override (auto-detected from extension if omitted)")
     .action(
-      async (file: string, opts: { contentType?: string }) => {
-        const { readFile, stat } = await import("fs/promises");
-        const { basename, extname } = await import("path");
-
-        // Read file
-        const buffer = await readFile(file);
-        const fileName = basename(file);
-        const fileSize = (await stat(file)).size;
-
-        // Auto-detect content type from extension
-        const ext = extname(file).toLowerCase();
-        const mimeMap: Record<string, string> = {
-          ".png": "image/png",
-          ".jpg": "image/jpeg",
-          ".jpeg": "image/jpeg",
-          ".webp": "image/webp",
-          ".gif": "image/gif",
-          ".mp4": "video/mp4",
-          ".mov": "video/quicktime",
-          ".mp3": "audio/mpeg",
-          ".wav": "audio/wav",
-        };
-        const contentType = opts.contentType || mimeMap[ext] || "application/octet-stream";
-
-        // Step 1: Initialize upload
-        const initResp = (await apiPost("/media-gen/media/initialize", {
-          fileName,
-          contentType,
-          fileSize,
-        })) as Record<string, unknown>;
-        const initData = unwrapResp(initResp) as Record<string, unknown>;
-        const mediaId = initData.mediaId as string;
-        const uploadUrl = initData.uploadUrl as string;
-
-        if (!mediaId || !uploadUrl) {
-          throw new Error("Upload initialization failed: missing mediaId or uploadUrl");
-        }
-
-        // Step 2: PUT file to presigned URL
-        const putRes = await fetch(uploadUrl, {
-          method: "PUT",
-          headers: { "Content-Type": contentType },
-          body: buffer,
-        });
-        if (!putRes.ok) {
-          throw new Error(`Upload failed: ${putRes.status} ${await putRes.text()}`);
-        }
-
-        // Step 3: Finalize
-        const finalResp = (await apiPost("/media-gen/media/finalize", {
-          mediaId,
-        })) as Record<string, unknown>;
-        const finalData = unwrapResp(finalResp) as Record<string, unknown>;
-
+      async (file: string) => {
+        const mediaId = await uploadFile(file);
         if (isJsonMode(media)) {
-          jsonOut({ mediaId, ...finalData });
+          jsonOut({ mediaId });
           return;
         }
-
-        console.log(`Uploaded ${fileName} (${fileSize} bytes)\n  Media ID: ${mediaId}`);
+        console.log(`Uploaded → Media ID: ${mediaId}`);
       },
     );
 
@@ -224,8 +215,8 @@ export function registerMediaCommand(program: Command): void {
     .requiredOption("--voice-id <voiceId>", "Voice to use")
     .requiredOption("--script <script>", "Script for the avatar to read")
     .option(
-      "--background-media-id <backgroundMediaId>",
-      "Background media ID (from upload)",
+      "--background <file>",
+      "Background image file (auto-uploaded)",
     )
     .option("--wait", "Poll until generation completes")
     .option("-o, --output <path>", "Download video to this path when done (implies --wait)")
@@ -235,7 +226,7 @@ export function registerMediaCommand(program: Command): void {
         avatarId: string;
         voiceId: string;
         script: string;
-        backgroundMediaId?: string;
+        background?: string;
         wait?: boolean;
         output?: string;
       }) => {
@@ -247,8 +238,8 @@ export function registerMediaCommand(program: Command): void {
           voiceId: opts.voiceId,
           script: opts.script,
         };
-        if (opts.backgroundMediaId)
-          body.backgroundMediaId = opts.backgroundMediaId;
+        if (opts.background)
+          body.backgroundMediaId = await uploadFile(opts.background);
 
         const resp = (await apiPost(
           "/media-gen/videos",
@@ -462,9 +453,9 @@ export function registerMediaCommand(program: Command): void {
     .option("--generate-audio", "Generate audio for the video")
     .option("--negative-prompt <negativePrompt>", "Negative prompt")
     .option("--sample-count <count>", "Number of samples (1-4)")
-    .option("--first-frame-media-id <mediaId>", "First frame image media ID")
-    .option("--last-frame-media-id <mediaId>", "Last frame image media ID")
-    .option("--reference-media-ids <ids>", "Comma-separated reference image media IDs (max 3)")
+    .option("--first-frame <file>", "First frame image file (auto-uploaded)")
+    .option("--last-frame <file>", "Last frame image file (auto-uploaded)")
+    .option("--reference-images <files>", "Comma-separated reference image files (auto-uploaded, max 3)")
     .option("--wait", "Poll until generation completes")
     .option("-o, --output <path>", "Download video to this path when done (implies --wait)")
     .action(
@@ -478,9 +469,9 @@ export function registerMediaCommand(program: Command): void {
         generateAudio?: boolean;
         negativePrompt?: string;
         sampleCount?: string;
-        firstFrameMediaId?: string;
-        lastFrameMediaId?: string;
-        referenceMediaIds?: string;
+        firstFrame?: string;
+        lastFrame?: string;
+        referenceImages?: string;
         wait?: boolean;
         output?: string;
       }) => {
@@ -505,9 +496,12 @@ export function registerMediaCommand(program: Command): void {
           if (Number.isNaN(v)) throw new Error("--sample-count must be a number");
           body.sampleCount = v;
         }
-        if (opts.firstFrameMediaId) body.firstFrameImageMediaId = opts.firstFrameMediaId;
-        if (opts.lastFrameMediaId) body.lastFrameImageMediaId = opts.lastFrameMediaId;
-        if (opts.referenceMediaIds) body.referenceImageMediaIds = opts.referenceMediaIds.split(",").map((s) => s.trim());
+        if (opts.firstFrame) body.firstFrameImageMediaId = await uploadFile(opts.firstFrame);
+        if (opts.lastFrame) body.lastFrameImageMediaId = await uploadFile(opts.lastFrame);
+        if (opts.referenceImages) {
+          const files = opts.referenceImages.split(",").map((s: string) => s.trim());
+          body.referenceImageMediaIds = await Promise.all(files.map((f: string) => uploadFile(f)));
+        }
 
         const resp = (await apiPost(
           "/media-gen/videos/cinematic",
@@ -569,7 +563,7 @@ export function registerMediaCommand(program: Command): void {
     .requiredOption("--outfit <outfit>", "Outfit description")
     .requiredOption("--background <background>", "Background description")
     .option("--no-portrait", "Generate full-body instead of portrait")
-    .option("--audio-media-id <mediaId>", "Custom voice audio media ID")
+    .option("--audio <file>", "Custom voice audio file (auto-uploaded)")
     .option("--wait", "Poll until variants are ready")
     .action(
       async (opts: {
@@ -580,7 +574,7 @@ export function registerMediaCommand(program: Command): void {
         outfit: string;
         background: string;
         portrait: boolean;
-        audioMediaId?: string;
+        audio?: string;
         wait?: boolean;
       }) => {
         const body: Record<string, unknown> = {
@@ -592,7 +586,7 @@ export function registerMediaCommand(program: Command): void {
           background: opts.background,
           isPortrait: opts.portrait,
         };
-        if (opts.audioMediaId) body.audioMediaId = opts.audioMediaId;
+        if (opts.audio) body.audioMediaId = await uploadFile(opts.audio);
 
         const resp = (await apiPost(
           "/media-gen/avatars/design",
@@ -663,24 +657,24 @@ export function registerMediaCommand(program: Command): void {
     .command("avatar-from-selfie")
     .description("Create an avatar from a selfie (instant or enhanced with prompt).")
     .option("--name <name>", "Name for the avatar (auto-generated if omitted)")
-    .requiredOption("--photo-media-id <mediaId>", "Selfie photo media ID")
+    .requiredOption("--photo <file>", "Selfie photo file (auto-uploaded)")
     .option("--prompt <prompt>", "Enhancement prompt (triggers async enhance flow)")
-    .option("--audio-media-id <mediaId>", "Custom voice audio media ID")
+    .option("--audio <file>", "Custom voice audio file (auto-uploaded)")
     .option("--wait", "Poll until job completes (only for enhance flow)")
     .action(
       async (opts: {
         name?: string;
-        photoMediaId: string;
+        photo: string;
         prompt?: string;
-        audioMediaId?: string;
+        audio?: string;
         wait?: boolean;
       }) => {
         const body: Record<string, unknown> = {
           name: opts.name || `avatar-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`,
-          photoMediaId: opts.photoMediaId,
+          photoMediaId: await uploadFile(opts.photo),
         };
         if (opts.prompt) body.prompt = opts.prompt;
-        if (opts.audioMediaId) body.audioMediaId = opts.audioMediaId;
+        if (opts.audio) body.audioMediaId = await uploadFile(opts.audio);
 
         const resp = (await apiPost(
           "/media-gen/avatars/from-selfie",
@@ -769,8 +763,8 @@ export function registerMediaCommand(program: Command): void {
     .option("--negative-prompt <negativePrompt>", "Negative prompt")
     .option("--seed <seed>", "Random seed for reproducibility")
     .option(
-      "--reference-media-id <referenceMediaId>",
-      "Reference image media ID",
+      "--reference-image <file>",
+      "Reference image file (auto-uploaded)",
     )
     .option("--wait", "Poll until generation completes")
     .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
@@ -782,7 +776,7 @@ export function registerMediaCommand(program: Command): void {
         aspectRatio?: string;
         negativePrompt?: string;
         seed?: string;
-        referenceMediaId?: string;
+        referenceImage?: string;
         wait?: boolean;
         output?: string;
       }) => {
@@ -796,7 +790,7 @@ export function registerMediaCommand(program: Command): void {
         if (opts.aspectRatio) body.aspectRatio = opts.aspectRatio;
         if (opts.negativePrompt) body.negativePrompt = opts.negativePrompt;
         if (opts.seed) body.seed = parseInt(opts.seed, 10);
-        if (opts.referenceMediaId) body.referenceMediaId = opts.referenceMediaId;
+        if (opts.referenceImage) body.referenceMediaId = await uploadFile(opts.referenceImage);
 
         const resp = (await apiPost(
           "/media-gen/images/generate",
@@ -864,17 +858,18 @@ export function registerMediaCommand(program: Command): void {
   media
     .command("image-edit")
     .description("Edit an existing image with a prompt (image-to-image).")
-    .requiredOption("--media-id <mediaId>", "Source image media ID")
+    .requiredOption("--image <file>", "Source image file (auto-uploaded)")
     .requiredOption("--prompt <prompt>", "Edit instruction")
     .option("--name <name>", "Name for the edited image (auto-generated if omitted)")
     .option("--wait", "Poll until generation completes")
     .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
     .action(
-      async (opts: { mediaId: string; prompt: string; name?: string; wait?: boolean; output?: string }) => {
+      async (opts: { image: string; prompt: string; name?: string; wait?: boolean; output?: string }) => {
         const shouldWait = opts.wait || !!opts.output;
+        const mediaId = await uploadFile(opts.image);
         const autoName = opts.name || opts.prompt.slice(0, 50).replace(/[^a-zA-Z0-9-_ ]/g, "").trim().replace(/\s+/g, "-");
         const resp = (await apiPost("/media-gen/images/edit", {
-          mediaId: opts.mediaId,
+          mediaId,
           prompt: opts.prompt,
           name: autoName,
         })) as Record<string, unknown>;
@@ -935,26 +930,30 @@ export function registerMediaCommand(program: Command): void {
   media
     .command("image-inpaint")
     .description("Inpaint an image region using a mask.")
-    .requiredOption("--media-id <mediaId>", "Source image media ID")
-    .requiredOption("--mask-media-id <maskMediaId>", "Mask image media ID")
+    .requiredOption("--image <file>", "Source image file (auto-uploaded)")
+    .requiredOption("--mask <file>", "Mask image file (auto-uploaded)")
     .requiredOption("--prompt <prompt>", "Inpainting prompt")
     .option("--name <name>", "Name for the inpainted image (auto-generated if omitted)")
     .option("--wait", "Poll until generation completes")
     .option("-o, --output <path>", "Download image to this path when done (implies --wait)")
     .action(
       async (opts: {
-        mediaId: string;
-        maskMediaId: string;
+        image: string;
+        mask: string;
         prompt: string;
         name?: string;
         wait?: boolean;
         output?: string;
       }) => {
         const shouldWait = opts.wait || !!opts.output;
+        const [mediaId, maskMediaId] = await Promise.all([
+          uploadFile(opts.image),
+          uploadFile(opts.mask),
+        ]);
         const autoName = opts.name || opts.prompt.slice(0, 50).replace(/[^a-zA-Z0-9-_ ]/g, "").trim().replace(/\s+/g, "-");
         const resp = (await apiPost("/media-gen/images/inpaint", {
-          mediaId: opts.mediaId,
-          maskMediaId: opts.maskMediaId,
+          mediaId,
+          maskMediaId,
           prompt: opts.prompt,
           name: autoName,
         })) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Refactor media commands to accept local file paths; replace upload-init/upload-finalize with single `upload` command
- Expand gobi-homepage skill with polished patterns (design tokens, knowledge graph, overlays, chat chips)
- Bump version to 0.9.11

## Test plan
- [ ] Verify media commands work with local file paths
- [ ] Verify release workflow publishes to npm, Homebrew, and Claude Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)