### PR TITLE
[GOB-13] Add BRAIN.md frontmatter docs to gobi-brain skill

### DIFF
--- a/skills/gobi-brain/SKILL.md
+++ b/skills/gobi-brain/SKILL.md
@@ -51,6 +51,63 @@ gobi --json brain search --query "machine learning"
 - `gobi brain edit-update` — Edit a published brain update. You must be the author.
 - `gobi brain delete-update` — Delete a published brain update. You must be the author.
 
+## BRAIN.md Frontmatter Reference
+
+`BRAIN.md` is the metadata file at the root of every vault. Its YAML frontmatter controls the vault's public profile, homepage, and AI agent behavior. Example:
+
+```yaml
+---
+title: My Brain
+tags:
+  - topic1
+  - topic2
+description: A short description of what this brain is about.
+thumbnail: "[[BRAIN.png]]"
+homepage: "[[app/home.html?nav=false]]"
+prompt: "[[system-prompt.md]]"
+---
+```
+
+### Fields
+
+- **`title`** (required) — Display name of the brain/vault.
+- **`description`** (required for public listing) — Short description shown on the brain card and public profile. Without both `title` and `description`, the brain won't appear in the public catalog.
+- **`tags`** — Tags for categorization and discovery. Supports YAML block list or inline array format:
+  ```yaml
+  # Block list
+  tags:
+    - ambient ai
+    - wearables
+
+  # Inline array
+  tags: [ambient ai, wearables]
+  ```
+- **`thumbnail`** — Profile image for the brain card. Uses wiki-link syntax pointing to an image file in the vault (e.g. `"[[BRAIN.png]]"`).
+- **`homepage`** — Custom HTML page to serve as the vault's public homepage at `gobispace.com/@{vaultSlug}`. Uses wiki-link syntax pointing to an HTML file in the vault. Supports a `nav` query parameter to control Gobi's sidebar navigation:
+  - `"[[app/home.html]]"` — Shows the Gobi sidebar alongside the homepage (default)
+  - `"[[app/home.html?nav=false]]"` — Full-screen, no Gobi sidebar/chrome
+- **`prompt`** — Wiki-link to a custom system prompt file for the brain's AI agent (e.g. `"[[system-prompt.md]]"`).
+
+> For details on building custom HTML homepages and using the `window.gobi` API, see the **gobi-homepage** skill.
+
+## Publishing Workflow
+
+After editing `BRAIN.md` frontmatter, follow these steps to make your changes live:
+
+1. **Edit `BRAIN.md`** in the vault root with the desired frontmatter fields.
+2. **Sync referenced files** — if the homepage HTML, thumbnail image, or prompt file is new or updated, upload them first:
+   ```bash
+   gobi sync
+   ```
+3. **Publish the brain**:
+   ```bash
+   gobi brain publish
+   ```
+   This uploads `BRAIN.md` to webdrive, triggers post-processing that extracts metadata (title, description, tags, thumbnail, homepage path), updates the vault's public profile, and sends a Discord notification.
+4. The vault is now live at `https://gobispace.com/@{vaultSlug}`.
+
+> **Important:** Any time you change `BRAIN.md` frontmatter (e.g. adding or updating `homepage`), you must re-run `gobi brain publish` for the changes to take effect.
+
 ## Reference Documentation
 
 - [gobi brain](references/brain.md)


### PR DESCRIPTION
## Linear Issue
https://linear.app/gobi-chapter-2/issue/GOB-13/gobi-cli-instruction-to-add-to-brainmd

## Summary
Users building custom homepages didn't know they need to add the `homepage` frontmatter field to `BRAIN.md` and publish via `gobi brain publish`. The user's Second Brain Agent couldn't guide them because the gobi-brain skill documentation had no mention of BRAIN.md frontmatter fields.

## Changes
- `skills/gobi-brain/SKILL.md`: Added two new sections between "Available Commands" and "Reference Documentation":
  - **BRAIN.md Frontmatter Reference** — Documents all 6 supported fields (`title`, `description`, `tags`, `thumbnail`, `homepage`, `prompt`) with examples, wiki-link syntax, and `nav` query parameter behavior
  - **Publishing Workflow** — Step-by-step guide: edit BRAIN.md → sync files → publish → verify

## Test Plan
- [ ] Verify the skill doc renders correctly when loaded by Claude Code
- [ ] Confirm the gobi-brain agent can now guide users through setting up `homepage` in BRAIN.md
- [ ] Check cross-reference to gobi-homepage skill is accurate