### PR TITLE
Release v1.3.5 — bump-only sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump to 1.3.5 across `package.json`, `marketplace.json`, `plugin.json`, `package-lock.json`.
- All feature changes (proposal subcommand, gobi-proposal skill, GOB-24 brain/space cleanup, global commands) already on develop and shipped via npm tag v1.3.5.

## Test plan
- [x] CI release workflow ✓ (npm publish + GH Release)
- [x] Homebrew formula updated to v1.3.5
- [ ] Marketplace consumers receive 1.3.5 on next plugin sync (after this PR merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)