### PR TITLE
Release v1.3.6 — proposal redesign (title + required session)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Search and ask brains, publish brain documents, create threads, manage sessions, generate images and videos.",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "gobi-ai"
   },

--- a/README.md
+++ b/README.md
@@ -166,19 +166,19 @@ Times are ISO 8601 UTC (e.g. `2026-03-20T00:00:00Z`).
 
 ### Proposals
 
-Proposals are authored by your agent during chat (or by external agents using `gobi proposal add` as their tool layer). The top 5 pending proposals (lowest priority first) feed the agent's system prompt every turn.
+Proposals are authored by your agent during chat (or by external agents using `gobi proposal add` as their tool layer). The top 5 pending proposals (lowest priority first) feed the agent's system prompt every turn. Every proposal is anchored to the chat session that produced it.
 
 | Command | Description |
 |---------|-------------|
 | `gobi proposal list [--limit N]` | List proposals (priority ASC, then newest first) |
 | `gobi proposal get <id>` | Show one proposal with its history |
-| `gobi proposal add <content> [--session <id>] [--priority N]` | Add a proposal (use `-` for stdin) |
-| `gobi proposal edit <id> <content>` | Replace content; bumps revision |
+| `gobi proposal add <title> <content> [--session <id>] [--priority N]` | Add a proposal (use `-` for content to read from stdin). `--session` falls back to `$GOBI_SESSION_ID`. |
+| `gobi proposal edit <id> [--title <t>] [--content <c>]` | Update title and/or content; bumps revision (use `-` for stdin) |
 | `gobi proposal delete <id>` | Delete a proposal |
 | `gobi proposal prioritize <id> <priority>` | Set priority (lower = higher) |
-| `gobi proposal accept <id>` | Accept; posts "Accept your proposal X" into the originating session |
-| `gobi proposal reject <id>` | Reject; posts "Reject your proposal X" into the originating session |
-| `gobi proposal revise <id> <comment>` | Ask the agent to revise; posts the comment into the session |
+| `gobi proposal accept <id>` | Mark as accepted (the client posts the synthesized message into the session) |
+| `gobi proposal reject <id>` | Mark as rejected |
+| `gobi proposal revise <id> <comment>` | Mark for revision and record the user's comment |
 
 ### Sync
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-proposal/SKILL.md
+++ b/skills/gobi-proposal/SKILL.md
@@ -22,18 +22,21 @@ Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 
 A proposal is a unit of standing guidance authored by an agent (in-process during chat, or via `gobi proposal add` when the agent uses gobi-cli as its tool layer). Each proposal has:
 
-- **content** — the proposal text (markdown, up to 8000 chars)
+- **title** — short headline (1–200 chars)
+- **content** — the proposal text (markdown, 1–8000 chars)
+- **sessionId** — required; the chat session that produced the proposal
 - **priority** — lower number = higher priority; default `100`
 - **status** — `pending`, `accepted`, or `rejected`
-- **revision** — bumped each time the content is edited
-- **sessionId** — optional; the chat session the proposal originated from
+- **revision** — bumped each time the title or content is edited
 - **history** — append-only log of `created`, `edited`, `prioritized`, `accepted`, `rejected`, and `revise_requested` events
 
 The top 5 pending proposals (lowest priority first) are injected into the agent's system prompt every turn — that's how proposals turn into standing instructions.
 
+When invoked from inside an agent run, the runtime exports `GOBI_SESSION_ID` so `gobi proposal add` picks it up automatically; otherwise pass `--session <uuid>`.
+
 ## Lifecycle
 
-`accept` and `reject` are terminal: they post a synthesized user message into the originating chat session ("Accept your proposal X" / "Reject your proposal X") so the agent can react. `revise` keeps the proposal pending and posts the user's comment into the session, asking the agent to revise. Only pending proposals can be revised.
+`accept`, `reject`, and `revise` update the proposal's status and history. They do **not** themselves post messages into the chat session — the client (e.g. the floating proposal bubble) opens at `proposal.sessionId` and sends the synthesized message via SSE so the user sees the agent's reply stream in. Only pending proposals can be revised.
 
 ## Important: JSON Mode
 
@@ -41,7 +44,7 @@ For programmatic/agent usage, always pass `--json` as a **global** option (befor
 
 ```bash
 gobi --json proposal list --limit 20
-gobi --json proposal add "Prefer concise titles" --priority 50
+gobi --json proposal add "Concise titles" "Prefer concise titles for brain updates." --priority 50
 ```
 
 JSON mode wraps the response as `{"success": true, "data": <proposal>}` (or `{"success": false, "error": "..."}`).

--- a/skills/gobi-proposal/SKILL.md
+++ b/skills/gobi-proposal/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "1.3.4"
+  version: "1.3.6"
 ---
 
 # gobi-proposal
 
-Gobi proposal commands for managing agent-authored proposals (v1.3.4).
+Gobi proposal commands for managing agent-authored proposals (v1.3.6).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-proposal/references/proposal.md
+++ b/skills/gobi-proposal/references/proposal.md
@@ -3,7 +3,7 @@
 ```
 Usage: gobi proposal [options] [command]
 
-Proposals authored by your agent during chat. Top-5 feed the system prompt; accept/reject/revise post into the originating chat session.
+Proposals authored by your agent during chat. Top-5 feed the system prompt; accept/reject/revise update state and the client posts the synthesized message into the session.
 
 Options:
   -h, --help                          display help for command
@@ -11,13 +11,14 @@ Options:
 Commands:
   list [options]                      List proposals (priority ASC, then newest first).
   get <proposalId>                    Show one proposal with its history.
-  add [options] <content>             Add a proposal directly. Pass '-' to read from stdin.
-  edit <proposalId> <content>         Replace proposal content (bumps revision). Pass '-' for stdin.
+  add [options] <title> <content>     Add a proposal. Pass '-' for content to read from stdin. Requires a chat session — the agent runtime exports GOBI_SESSION_ID automatically; outside that, pass
+                                      --session.
+  edit [options] <proposalId>         Replace proposal title and/or content (bumps revision). Pass '-' for stdin.
   delete <proposalId>                 Delete a proposal.
   prioritize <proposalId> <priority>  Set priority (lower = higher). Top 5 feed the system prompt.
-  accept <proposalId>                 Accept — posts "Accept your proposal X" into the originating chat session.
-  reject <proposalId>                 Reject — posts "Reject your proposal X" into the originating chat session.
-  revise <proposalId> <comment>       Ask the agent to revise — posts "Update your proposal X. Here's my comment. {comment}" into the chat session.
+  accept <proposalId>                 Mark the proposal accepted. The client posts the synthesized message into the session.
+  reject <proposalId>                 Mark the proposal rejected. The client posts the synthesized message into the session.
+  revise <proposalId> <comment>       Mark the proposal for revision and record the user's comment. The client posts the synthesized message into the session.
   help [command]                      display help for command
 ```
 
@@ -47,12 +48,12 @@ Options:
 ## add
 
 ```
-Usage: gobi proposal add [options] <content>
+Usage: gobi proposal add [options] <title> <content>
 
-Add a proposal directly. Pass '-' to read from stdin.
+Add a proposal. Pass '-' for content to read from stdin. Requires a chat session — the agent runtime exports GOBI_SESSION_ID automatically; outside that, pass --session.
 
 Options:
-  --session <sessionId>  Originate from a chat session (UUID)
+  --session <sessionId>  Originating chat session UUID. Falls back to $GOBI_SESSION_ID when set.
   --priority <number>    Priority (lower = higher), default 100
   -h, --help             display help for command
 ```
@@ -60,12 +61,14 @@ Options:
 ## edit
 
 ```
-Usage: gobi proposal edit [options] <proposalId> <content>
+Usage: gobi proposal edit [options] <proposalId>
 
-Replace proposal content (bumps revision). Pass '-' for stdin.
+Replace proposal title and/or content (bumps revision). Pass '-' for stdin.
 
 Options:
-  -h, --help  display help for command
+  --title <title>      New title
+  --content <content>  New content; pass '-' to read from stdin
+  -h, --help           display help for command
 ```
 
 ## delete
@@ -95,7 +98,7 @@ Options:
 ```
 Usage: gobi proposal accept [options] <proposalId>
 
-Accept — posts "Accept your proposal X" into the originating chat session.
+Mark the proposal accepted. The client posts the synthesized message into the session.
 
 Options:
   -h, --help  display help for command
@@ -106,7 +109,7 @@ Options:
 ```
 Usage: gobi proposal reject [options] <proposalId>
 
-Reject — posts "Reject your proposal X" into the originating chat session.
+Mark the proposal rejected. The client posts the synthesized message into the session.
 
 Options:
   -h, --help  display help for command
@@ -117,7 +120,7 @@ Options:
 ```
 Usage: gobi proposal revise [options] <proposalId> <comment>
 
-Ask the agent to revise — posts "Update your proposal X. Here's my comment. {comment}" into the chat session.
+Mark the proposal for revision and record the user's comment. The client posts the synthesized message into the session.
 
 Options:
   -h, --help  display help for command

--- a/src/commands/proposal.ts
+++ b/src/commands/proposal.ts
@@ -12,6 +12,7 @@ interface ProposalHistoryEvent {
     | "revise_requested"
     | "prioritized";
   revision: number;
+  title?: string;
   content?: string;
   comment?: string;
   priority?: number;
@@ -22,9 +23,10 @@ interface Proposal {
   id: number;
   proposalId: string;
   userId: number;
-  sessionId: string | null;
+  sessionId: string;
   revision: number;
   priority: number;
+  title: string;
   content: string;
   history: ProposalHistoryEvent[];
   status: "pending" | "accepted" | "rejected";
@@ -45,14 +47,14 @@ function snippet(content: string, max = 80): string {
 function formatProposalLine(p: Proposal): string {
   const status =
     p.status === "pending" ? "·" : p.status === "accepted" ? "✓" : "✗";
-  return `- [${status}] p${p.priority} rev${p.revision} ${p.proposalId.slice(0, 8)}  ${snippet(p.content)}`;
+  return `- [${status}] p${p.priority} rev${p.revision} ${p.proposalId.slice(0, 8)}  ${snippet(p.title)}`;
 }
 
 export function registerProposalCommand(program: Command): void {
   const proposal = program
     .command("proposal")
     .description(
-      "Proposals authored by your agent during chat. Top-5 feed the system prompt; accept/reject/revise post into the originating chat session.",
+      "Proposals authored by your agent during chat. Top-5 feed the system prompt; accept/reject/revise update state and the client posts the synthesized message into the session.",
     );
 
   // ── List ──
@@ -95,10 +97,11 @@ export function registerProposalCommand(program: Command): void {
       }
 
       console.log(`Proposal ${p.proposalId}`);
+      console.log(`  title:    ${p.title}`);
       console.log(`  status:   ${p.status}`);
       console.log(`  priority: ${p.priority}`);
       console.log(`  revision: ${p.revision}`);
-      console.log(`  session:  ${p.sessionId ?? "(none)"}`);
+      console.log(`  session:  ${p.sessionId}`);
       console.log(`  created:  ${p.createdAt}`);
       console.log("");
       console.log("Content:");
@@ -121,17 +124,33 @@ export function registerProposalCommand(program: Command): void {
   // ── Add ──
 
   proposal
-    .command("add <content>")
-    .description("Add a proposal directly. Pass '-' to read from stdin.")
-    .option("--session <sessionId>", "Originate from a chat session (UUID)")
+    .command("add <title> <content>")
+    .description(
+      "Add a proposal. Pass '-' for content to read from stdin. Requires a chat session — the agent runtime exports GOBI_SESSION_ID automatically; outside that, pass --session.",
+    )
+    .option(
+      "--session <sessionId>",
+      "Originating chat session UUID. Falls back to $GOBI_SESSION_ID when set.",
+    )
     .option("--priority <number>", "Priority (lower = higher), default 100")
     .action(
       async (
+        title: string,
         content: string,
         opts: { session?: string; priority?: string },
       ) => {
-        const body: Record<string, unknown> = { content: readContent(content) };
-        if (opts.session) body.sessionId = opts.session;
+        const sessionId = opts.session || process.env.GOBI_SESSION_ID || "";
+        if (!sessionId) {
+          console.error(
+            "Error: missing session id. Pass --session <uuid> or set GOBI_SESSION_ID in the environment.",
+          );
+          process.exit(1);
+        }
+        const body: Record<string, unknown> = {
+          title,
+          content: readContent(content),
+          sessionId,
+        };
         if (opts.priority) body.priority = parseInt(opts.priority, 10);
 
         const resp = (await apiPost("/app/proposals", body)) as Record<string, unknown>;
@@ -149,21 +168,33 @@ export function registerProposalCommand(program: Command): void {
   // ── Edit content ──
 
   proposal
-    .command("edit <proposalId> <content>")
-    .description("Replace proposal content (bumps revision). Pass '-' for stdin.")
-    .action(async (proposalId: string, content: string) => {
-      const resp = (await apiPatch(`/app/proposals/${proposalId}`, {
-        content: readContent(content),
-      })) as Record<string, unknown>;
-      const p = unwrapResp(resp) as Proposal;
+    .command("edit <proposalId>")
+    .description("Replace proposal title and/or content (bumps revision). Pass '-' for stdin.")
+    .option("--title <title>", "New title")
+    .option("--content <content>", "New content; pass '-' to read from stdin")
+    .action(
+      async (
+        proposalId: string,
+        opts: { title?: string; content?: string },
+      ) => {
+        const body: Record<string, unknown> = {};
+        if (opts.title !== undefined) body.title = opts.title;
+        if (opts.content !== undefined) body.content = readContent(opts.content);
+        if (Object.keys(body).length === 0) {
+          console.error('Error: pass --title and/or --content.');
+          process.exit(1);
+        }
+        const resp = (await apiPatch(`/app/proposals/${proposalId}`, body)) as Record<string, unknown>;
+        const p = unwrapResp(resp) as Proposal;
 
-      if (isJsonMode(proposal)) {
-        jsonOut(p);
-        return;
-      }
+        if (isJsonMode(proposal)) {
+          jsonOut(p);
+          return;
+        }
 
-      console.log(`Updated ${p.proposalId} → rev${p.revision}.`);
-    });
+        console.log(`Updated ${p.proposalId} → rev${p.revision}.`);
+      },
+    );
 
   // ── Delete ──
 
@@ -205,7 +236,7 @@ export function registerProposalCommand(program: Command): void {
   proposal
     .command("accept <proposalId>")
     .description(
-      'Accept — posts "Accept your proposal X" into the originating chat session.',
+      "Mark the proposal accepted. The client posts the synthesized message into the session.",
     )
     .action(async (proposalId: string) => {
       const resp = (await apiPost(`/app/proposals/${proposalId}/accept`)) as Record<string, unknown>;
@@ -224,7 +255,7 @@ export function registerProposalCommand(program: Command): void {
   proposal
     .command("reject <proposalId>")
     .description(
-      'Reject — posts "Reject your proposal X" into the originating chat session.',
+      "Mark the proposal rejected. The client posts the synthesized message into the session.",
     )
     .action(async (proposalId: string) => {
       const resp = (await apiPost(`/app/proposals/${proposalId}/reject`)) as Record<string, unknown>;
@@ -243,7 +274,7 @@ export function registerProposalCommand(program: Command): void {
   proposal
     .command("revise <proposalId> <comment>")
     .description(
-      'Ask the agent to revise — posts "Update your proposal X. Here\'s my comment. {comment}" into the chat session.',
+      "Mark the proposal for revision and record the user's comment. The client posts the synthesized message into the session.",
     )
     .action(async (proposalId: string, comment: string) => {
       const resp = (await apiPost(`/app/proposals/${proposalId}/revise`, {


### PR DESCRIPTION
## Summary
- Proposal command updated for the backend redesign: `add` now takes `<title> <content>` and requires a session (via `--session` or `$GOBI_SESSION_ID`); `edit` switched to `--title` / `--content` flags.
- Accept/reject/revise descriptions updated — backend no longer posts the synthesized message; the client (proposal bubble) drives that via SSE.
- Bumps to 1.3.6 across `package.json`, `marketplace.json`, `plugin.json`; regenerated skill docs.

## Test plan
- [x] End-to-end against prod with new schema (add → get → edit title → edit content → accept → delete) ✓
- [x] CI release workflow ✓ (npm publish + GH Release)
- [x] Homebrew formula updated to v1.3.6
- [ ] Marketplace consumers receive 1.3.6 on next plugin sync (after this PR merges)

## Behavior change
CLI users running `gobi proposal accept|reject|revise` outside the web client will no longer trigger a session message — the backend now updates state only. The web client posts the synthesized message via SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)