### PR TITLE
Skills: confirm-before-mutating guidance; bump 2.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -117,6 +117,14 @@ JSON responses have the shape `{ "success": true, "data": ... }` on success or `
 
 > File sync (`gobi vault sync`) lives in the **gobi-vault** skill.
 
+## Confirm before mutating
+
+`gobi session reply` posts a human-attributed message into a chat session — the message becomes part of the user's permanent chat history and triggers the agent to respond. Before running it, confirm with the user — show the exact session id and the message text. This applies even when running autonomously.
+
+`auth login` / `auth logout` and `init` are explicit user-driven commands; they prompt the user themselves and don't need an extra confirmation layer. `update` upgrades the CLI binary — fine to run without extra confirmation.
+
+Read-only commands (`auth status`, `session list`, `session get`, `space list`) run without confirmation.
+
 ## Reference Documentation
 
 - [gobi auth](references/auth.md)

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -85,6 +85,15 @@ When the user picks an action via `gobi draft action <id> <index>`, the response
   - `gobi draft action` — Take one of the draft's suggested actions by 0-based index. Posts the synthesized message into the originating session.
   - `gobi draft revise` — Bump the draft to a new revision with a comment, optionally replacing title / content / actions.
 
+## Confirm before mutating
+
+Drafts are agent-authored proposals — `add` and `revise` are the agent's normal authoring path and run without extra confirmation. Two commands flip that:
+
+- `draft action <id> <index>` — picking an action is **a user decision**. Marks the draft `actioned` (terminal — the agent can't take it back) and posts the action's `message` into the originating session. Don't pick on the user's behalf; only run this when the user has explicitly told you which action to take.
+- `draft delete <id>` — irreversible. Confirm the target id with the user before running.
+
+`draft prioritize` is low-stakes (just reorders the prompt feed) — fine to run when the user asks.
+
 ## Reference Documentation
 
 - [gobi draft](references/draft.md)

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -171,6 +171,17 @@ Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs. Always use `
 - `gobi media image-download` — Download a generated image.
 - `gobi media image-status` — Check image generation job status.
 
+## Confirm before mutating
+
+Media generation jobs consume credits (real-world billable cost) and produce assets attached to the user's account. Videos and avatar work can take minutes per job. Before running any generation/upload command, confirm with the user — show the exact command and the prompt / script / source files / aspect ratio / duration. This applies even when running autonomously.
+
+- `image-generate`, `image-edit`, `image-inpaint` — quick but billable per job.
+- `video-create`, `cinematic-create` — slower and more expensive; confirm script, avatar/voice ids, and aspect ratio before submitting.
+- `avatar-design`, `avatar-confirm`, `avatar-from-selfie` — produce assets the user will see in their avatar list. Confirm the photo/prompt and that the user wants the variant locked in (`avatar-confirm` is the commit step).
+- `upload` — adds to the user's media. Low-stakes but still a write; mention the file before uploading.
+
+Read-only commands (`avatars`, `voices`, `image-status`, `video-status`, `video-list`, `video-get`, `avatar-job-status`) and downloads (`image-download`, `video-download`) run without confirmation.
+
 ## Reference Documentation
 
 - [gobi media](references/media.md)

--- a/skills/gobi-saved/SKILL.md
+++ b/skills/gobi-saved/SKILL.md
@@ -54,6 +54,16 @@ gobi --json saved note list --date 2026-04-27
 - `gobi saved post create --source <id>` — Save a post or reply by id. Records a snapshot in your saved-posts collection.
 - `gobi saved post delete <postId>` — Remove a post from your saved-posts collection.
 
+## Confirm before mutating
+
+Saved items are the user's private collection but they still persist server-side and deletes are irreversible. Before running any write, confirm with the user — show the command and the note content / target id. This applies even when running autonomously.
+
+- `note create`, `note edit` — confirm the content (or content delta on edit).
+- `post create` (snapshotting a feed post) — confirm the source id you're about to bookmark.
+- `note delete`, `post delete` — irreversible. Flag that explicitly and confirm the target id before running.
+
+Read-only commands (`note list`, `note get`, `post list`, `post get`) run without confirmation.
+
 ## Reference Documentation
 
 - [gobi saved](references/saved.md)

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -94,6 +94,16 @@ gobi --json space list-posts
 - `gobi global edit-reply <replyId>` — Edit a reply you authored.
 - `gobi global delete-reply <replyId>` — Delete a reply you authored.
 
+## Confirm before mutating
+
+Posts and replies are publicly visible — in a community space (`gobi space …`) or in the global feed (`gobi global …`). Before running any write, confirm with the user — show the exact command and the resolved title, content (or a short preview), and `authorVaultSlug` if `--vault-slug` / `--auto-attachments` is set. This applies even when running autonomously.
+
+- `create-post` / `create-reply` — content goes live on submission.
+- `edit-post` / `edit-reply` — confirm the *new* content; people who already saw the original may re-see it.
+- `delete-post` / `delete-reply` — irreversible. Flag that explicitly and confirm the target id before running.
+
+Read-only commands (`list-posts`, `get-post`, `feed`, `list-topics`, `list-topic-posts`, `get`) run without confirmation.
+
 ## Reference Documentation
 
 - [gobi space](references/space.md)

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -34,6 +34,14 @@ gobi --json vault publish
 - `gobi vault unpublish` — Delete `PUBLISH.md` from the vault on webdrive.
 - `gobi vault sync` — Sync local vault files with Gobi Webdrive. Supports `--upload-only`, `--download-only`, `--conflict <ask|server|client|skip>`, `--dry-run`, `--full`, `--path <p>`, `--plan-file`, `--execute`.
 
+## Confirm before mutating
+
+Every command in this skill writes external state — webdrive files, the public vault profile, and a Discord notification on `publish`. Before running any of them, confirm with the user — show the exact command and the key changes (which `PUBLISH.md` fields, which paths will sync, which conflict policy). This applies even when running autonomously.
+
+- `vault publish` — public profile change + Discord ping. Always confirm.
+- `vault unpublish` — removes the live profile. Always confirm.
+- `vault sync` — can overwrite remote or local files. Run `--dry-run` first and show the user the plan before re-running without `--dry-run`. With `--conflict server` or `--conflict client`, name which side is going to be overwritten.
+
 ## PUBLISH.md Frontmatter Reference
 
 `PUBLISH.md` is the metadata file at the root of every vault. Its YAML frontmatter controls the vault's public profile, homepage, and AI agent behavior. Example:


### PR DESCRIPTION
## Summary
- Add a "Confirm before mutating" section to each affected skill (vault, space, media, saved, core, draft) so agents pause for explicit user approval before running write commands — even in autonomous modes. Read-only commands continue to run without confirmation.
- Per-skill highlights:
  - **gobi-vault** — `publish`, `unpublish`, `sync` (Discord ping, profile change, file overwrites).
  - **gobi-space** — all `create-post` / `edit-post` / `delete-post` and reply equivalents on `space` and `global`.
  - **gobi-media** — generation jobs (`image-generate`, `video-create`, `cinematic-create`, `avatar-*`, `upload`) consume credits.
  - **gobi-saved** — `note`/`post` `create` / `edit` / `delete`.
  - **gobi-core** — `session reply` posts into chat history.
  - **gobi-draft** — `draft action` is user-decision-only; `draft delete` is irreversible.
- Release: bumped to 2.0.3 — npm published, GitHub Release cut, Homebrew formula updated.

## Test plan
- [ ] `npm install -g @gobi-ai/cli@2.0.3` and `brew upgrade gobi` both pull 2.0.3.
- [ ] Open each updated SKILL.md and confirm the new section sits before "Reference Documentation" (or analogous tail) and lists the right commands.
- [ ] Spot-check that an agent loading the skill sees the approval section in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)