### PR TITLE
Sync develop → main: optional draft session, skill cleanups

### DIFF
--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -28,7 +28,7 @@ A draft is a unit of standing guidance authored by an agent (in-process during c
 - **actions** — 0–3 AI-suggested actions. Each action is `{ label, message? }`:
   - `label` — short button text (1–80 chars) the user sees, e.g. `"Apply"`, `"Skip"`.
   - `message` — optional (≤2000 chars). What the user is taken to be saying to the agent when they click that button. Falls back to `label` when omitted. Use this whenever the click should send something more specific than the button text — e.g. label `"Punch it up"`, message `"Tighten the opening paragraph and shorten the CTA"`.
-- **sessionId** — required; the chat session that produced the draft
+- **sessionId** — the chat session the draft is anchored to. Optional on create: when omitted, the server mints a fresh session anchored to the user's primary vault and seeds it with a tool-call entry representing the draft, so clicking an action later has somewhere to land.
 - **priority** — lower number = higher priority; default `100`
 - **status** — `pending` until the user picks an action, then `actioned`
 - **revision** — bumped each time the draft is revised
@@ -36,7 +36,7 @@ A draft is a unit of standing guidance authored by an agent (in-process during c
 
 The top 5 pending drafts (lowest priority first) are injected into the agent's system prompt every turn — that's how drafts turn into standing instructions.
 
-When invoked from inside an agent run, the runtime exports `GOBI_SESSION_ID` so `gobi draft add` picks it up automatically; otherwise pass `--session <uuid>`.
+When invoked from inside the Gobi agent runtime, `GOBI_SESSION_ID` is exported and `gobi draft add` picks it up automatically. Outside that runtime (e.g. local Claude Code, ad-hoc shells), you can either pass `--session <uuid>` to anchor to an existing chat session, or omit it entirely — the server will mint a new session and seed it with the draft so the action click lands somewhere coherent.
 
 ## Lifecycle
 

--- a/skills/gobi-draft/references/draft.md
+++ b/skills/gobi-draft/references/draft.md
@@ -11,8 +11,9 @@ Options:
 Commands:
   list [options]                        List drafts (priority ASC, then newest first).
   get <draftId>                         Show one draft with its history and suggested actions.
-  add [options] <title> <content>       Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Requires a chat session — the agent runtime
-                                        exports GOBI_SESSION_ID automatically; outside that, pass --session.
+  add [options] <title> <content>       Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Session id is optional: the Gobi agent
+                                        runtime exports GOBI_SESSION_ID automatically and `--session` takes precedence; if neither is set, the server mints a new chat session anchored to your primary
+                                        vault and seeds it with the draft so clicking an action later has somewhere to land.
   delete <draftId>                      Delete a draft.
   prioritize <draftId> <priority>       Set priority (lower = higher). Top 5 feed the system prompt.
   action <draftId> <actionIndex>        Take one of the draft's suggested actions by 0-based index. Marks the draft 'actioned' and the client posts the synthesized message into the originating
@@ -50,11 +51,11 @@ Options:
 ```
 Usage: gobi draft add [options] <title> <content>
 
-Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Requires a chat session — the agent runtime exports GOBI_SESSION_ID automatically;
-outside that, pass --session.
+Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Session id is optional: the Gobi agent runtime exports GOBI_SESSION_ID automatically
+and `--session` takes precedence; if neither is set, the server mints a new chat session anchored to your primary vault and seeds it with the draft so clicking an action later has somewhere to land.
 
 Options:
-  --session <sessionId>        Originating chat session UUID. Falls back to $GOBI_SESSION_ID when set.
+  --session <sessionId>        Originating chat session UUID. Falls back to $GOBI_SESSION_ID; if unset, the server creates a new session.
   --priority <number>          Priority (lower = higher), default 100
   --action <label[::message]>  Suggested action (repeatable, max 3). `label` is the button text; an optional `::message` suffix is what the user is taken to be saying to the agent on click. Without
                                the suffix, the message falls back to the label. (default: [])

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -31,6 +31,17 @@ Anything you can do to a Space Post (reply, edit, delete, attribute to a vault) 
 - When the user wants to explore or catch up on what's happening in their space, invoke `/gobi:space-explore`.
 - When the user wants to share or post learnings from the current session, invoke `/gobi:space-share`.
 
+## Authoring posts: title vs. content
+
+`create-post` (and `edit-post`) on both `gobi space` and `gobi global` take `--title` and `--content` as **separate** fields. The title is rendered as the post heading by the UI, so it must not also appear inside `--content`:
+
+- Do **not** repeat the title as a heading (`# My title`) or as the first line of `--content`. The reader will see it twice.
+- Start `--content` with the body itself.
+- If you only have a single blob of markdown, split it: take the first heading or sentence as `--title`, drop that line, and pass the rest as `--content`.
+- On `edit-post`, the same rule applies — if you change `--title`, scrub any duplicate of the old or new title from `--content` too.
+
+The same applies to replies: a reply has only `--content` (no title), so do not synthesize a title-like heading at the top of a reply either.
+
 ## Author vault attribution (`--vault-slug`)
 
 Both `gobi space create-post` / `edit-post` and `gobi global create-post` / `edit-post` accept `--vault-slug <slug>`. When set, the slug becomes the post's `authorVaultSlug` — the vault the user is posting on behalf of. The caller must hold `role: 'owner'` on that vault. Pass `--vault-slug ""` on edit to detach.

--- a/src/commands/draft.ts
+++ b/src/commands/draft.ts
@@ -168,11 +168,11 @@ export function registerDraftCommand(program: Command): void {
   draft
     .command("add <title> <content>")
     .description(
-      "Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Requires a chat session — the agent runtime exports GOBI_SESSION_ID automatically; outside that, pass --session.",
+      "Add a draft. Pass '-' for content to read from stdin. Pass --action up to 3 times to attach AI-suggested actions. Session id is optional: the Gobi agent runtime exports GOBI_SESSION_ID automatically and `--session` takes precedence; if neither is set, the server mints a new chat session anchored to your primary vault and seeds it with the draft so clicking an action later has somewhere to land.",
     )
     .option(
       "--session <sessionId>",
-      "Originating chat session UUID. Falls back to $GOBI_SESSION_ID when set.",
+      "Originating chat session UUID. Falls back to $GOBI_SESSION_ID; if unset, the server creates a new session.",
     )
     .option("--priority <number>", "Priority (lower = higher), default 100")
     .option(
@@ -191,18 +191,12 @@ export function registerDraftCommand(program: Command): void {
           action?: string[];
         },
       ) => {
-        const sessionId = opts.session || process.env.GOBI_SESSION_ID || "";
-        if (!sessionId) {
-          console.error(
-            "Error: missing session id. Pass --session <uuid> or set GOBI_SESSION_ID in the environment.",
-          );
-          process.exit(1);
-        }
+        const sessionId = opts.session || process.env.GOBI_SESSION_ID;
         const body: Record<string, unknown> = {
           title,
           content: readContent(content),
-          sessionId,
         };
+        if (sessionId) body.sessionId = sessionId;
         if (opts.priority) body.priority = parseInt(opts.priority, 10);
         const actions = parseActionFlags(opts.action);
         if (actions.length) body.actions = actions;


### PR DESCRIPTION
## Summary
- Roll up develop into main: spans v2.0.0 → v2.0.4 plus the latest doc/feature work.
- Latest commit: `gobi draft add` no longer requires a session id (server mints a new session when omitted).
- Skill doc cleanups: title-vs-content guidance for posts; drop internal repo names from draft skill/help text.

## Test plan
- [ ] CI green on PR
- [ ] `gobi draft add <title> <content>` works without `--session` and without `GOBI_SESSION_ID`
- [ ] `gobi draft add --help` no longer references internal repo names

🤖 Generated with [Claude Code](https://claude.com/claude-code)