### PR TITLE
Release 2.0.8: vault status diagnostic + link format docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/build.py
+++ b/docs/cheatsheet/build.py
@@ -187,7 +187,7 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.7</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.8</span></h1>
       <div class="tag">Spaces · Global · Vault · Saved · Sessions · Media</div>
     </div>
     <div class="setup">

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.7</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.8</span></h1>
       <div class="tag">Spaces · Global · Vault · Saved · Sessions · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.7).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.8).
 
 ## Prerequisites
 

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-draft
 
-Gobi draft commands for managing agent-authored drafts (v2.0.7).
+Gobi draft commands for managing agent-authored drafts (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.7).
+Gobi media generation commands (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-saved/SKILL.md
+++ b/skills/gobi-saved/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-saved
 
-Gobi saved-knowledge commands (v2.0.7).
+Gobi saved-knowledge commands (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.7).
+Gobi sense commands for activity and transcription data (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -48,6 +48,19 @@ Both `gobi space create-post` / `edit-post` and `gobi global create-post` / `edi
 
 `--auto-attachments` resolves a vault for upload and **also** uses it as `authorVaultSlug` automatically — one flag, two effects.
 
+> **Before using `--auto-attachments`, check that the target vault is published.** Run `gobi --json vault status` (or `gobi vault status --vault-slug <slug>`) and verify `isPublished: true`. Files uploaded to a non-public vault are stored on webdrive but are not reachable at `gobispace.com/@{vaultSlug}` — readers will see broken `[[wikilinks]]`. If the status reports unpublished, ask the user to run `gobi vault publish` first (it requires `title` and `description` in `PUBLISH.md`). See the **gobi-vault** skill.
+
+## Public link formats
+
+Once a post is created, you can build a shareable URL from the response:
+
+- **Personal post on a vault** — `https://gobispace.com/@{authorVaultSlug}?postId={id}` (e.g. `https://gobispace.com/@jyk?postId=144869`). This is the canonical share link for `gobi global` posts attributed to a vault.
+- **Personal post without a vault** (created with no `--vault-slug`) — use `https://gobispace.com/posts/{id}` as a direct fallback.
+- **Space post** — `https://gobispace.com/spaces/{spaceSlug}?postId={id}` (overlay on the space feed) or `https://gobispace.com/spaces/{spaceSlug}/posts/{id}` (dedicated page).
+- **Vault profile** — `https://gobispace.com/@{vaultSlug}`.
+
+When you echo a "Post created!" line (or the JSON response is consumed by another agent), include the assembled URL using the fields actually returned (`id`, `authorVaultSlug`, `spaceSlug`) — don't fabricate slugs.
+
 ## Prerequisites & space slug
 
 `gobi space` commands do **not** require a vault to be configured in `.gobi/settings.yaml`. They only need a space slug, which can come from either:

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-space
 
-Gobi space and global posts (v2.0.7).
+Gobi space and global posts (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -37,9 +37,22 @@ gobi --json vault publish
 
 - `gobi vault init` — Interactive: select an existing vault or create a new one. Writes `vaultSlug` to `.gobi/settings.yaml` in the current directory and seeds `PUBLISH.md`. Requires the user to be logged in (`gobi auth login`).
 - `gobi vault list` — List vaults you own. The primary vault is marked.
+- `gobi vault status` — Show the configured vault's publish state (`isPublished`), profile fields (`title`, `description`, `tags`), referenced files (`thumbnailPath`, `homepagePath`, `promptPath`), file count, and the public profile URL. Use this as a diagnostic before posting with `--auto-attachments` (see gobi-space skill) to confirm the vault is public — files uploaded to a non-public vault are stored on webdrive but are not visible at `gobispace.com/@{vaultSlug}` until you run `gobi vault publish`.
 - `gobi vault publish` — Upload `PUBLISH.md` to the vault root on webdrive. Triggers post-processing (vault profile sync, metadata update, Discord notification).
 - `gobi vault unpublish` — Delete `PUBLISH.md` from the vault on webdrive.
 - `gobi vault sync` — Sync local vault files with Gobi Webdrive. Supports `--upload-only`, `--download-only`, `--conflict <ask|server|client|skip>`, `--dry-run`, `--full`, `--path <p>`, `--plan-file`, `--execute`.
+
+## Public link formats
+
+Once a vault is published (i.e. `gobi vault status` reports `isPublished: yes`), it is reachable at predictable URLs:
+
+- **Vault profile** — `https://gobispace.com/@{vaultSlug}` (e.g. `https://gobispace.com/@jyk`).
+- **Direct link to a personal post on the vault** — `https://gobispace.com/@{vaultSlug}?postId={postId}` (e.g. `https://gobispace.com/@jyk?postId=144869`). Open in the vault profile with that post focused.
+- **Open a vault file in the profile** — `https://gobispace.com/@{vaultSlug}?file={path}` (path is relative to the vault root, e.g. `?file=notes/intro.md`).
+- **Serve a vault HTML file directly with the `window.gobi` bridge injected** — append `&raw=1`: `https://gobispace.com/@{vaultSlug}?file={path}&raw=1`.
+- **Custom homepage** — when `homepage` is set in `PUBLISH.md` frontmatter, the vault profile URL renders that HTML file. See **gobi-homepage** skill.
+
+When linking back to your own posts (e.g. "I wrote about this here: …"), assemble the URL from the post's `authorVaultSlug` and `id` rather than guessing.
 
 ## Confirm before mutating
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.7"
+  version: "2.0.8"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.7).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.8).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-vault/references/vault.md
+++ b/skills/gobi-vault/references/vault.md
@@ -6,15 +6,16 @@ Usage: gobi vault [options] [command]
 Vault commands (init, list, publish/unpublish profile, sync files).
 
 Options:
-  -h, --help      display help for command
+  -h, --help        display help for command
 
 Commands:
-  init            Select or create the vault for the current directory. Writes .gobi/settings.yaml and seeds PUBLISH.md.
-  list            List vaults you own.
-  publish         Upload PUBLISH.md to the vault root on webdrive. Triggers post-processing (vault sync, metadata update, Discord notification).
-  unpublish       Delete PUBLISH.md from the vault on webdrive.
-  sync [options]  Sync local vault files with Gobi Webdrive.
-  help [command]  display help for command
+  init              Select or create the vault for the current directory. Writes .gobi/settings.yaml and seeds PUBLISH.md.
+  list              List vaults you own.
+  status [options]  Show the configured vault's publish state and metadata (use before posting with --auto-attachments to confirm the vault is public).
+  publish           Upload PUBLISH.md to the vault root on webdrive. Triggers post-processing (vault sync, metadata update, Discord notification).
+  unpublish         Delete PUBLISH.md from the vault on webdrive.
+  sync [options]    Sync local vault files with Gobi Webdrive.
+  help [command]    display help for command
 ```
 
 ## init
@@ -37,6 +38,18 @@ List vaults you own.
 
 Options:
   -h, --help  display help for command
+```
+
+## status
+
+```
+Usage: gobi vault status [options]
+
+Show the configured vault's publish state and metadata (use before posting with --auto-attachments to confirm the vault is public).
+
+Options:
+  --vault-slug <vaultSlug>  Vault slug to inspect (defaults to .gobi/settings.yaml)
+  -h, --help                display help for command
 ```
 
 ## publish

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -57,6 +57,80 @@ export function registerVaultCommand(program: Command): void {
       console.log(`Vaults (${items.length}):\n` + lines.join("\n"));
     });
 
+  const statusCmd = vault
+    .command("status")
+    .description(
+      "Show the configured vault's publish state and metadata (use before posting with --auto-attachments to confirm the vault is public).",
+    )
+    .option(
+      "--vault-slug <vaultSlug>",
+      "Vault slug to inspect (defaults to .gobi/settings.yaml)",
+    )
+    .action(async (opts: { vaultSlug?: string }) => {
+      const slug = opts.vaultSlug ?? getVaultSlug();
+      const resp = (await apiGet("/vaults")) as unknown;
+      const items = (
+        Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as Record<string, unknown>)?.data)
+            ? ((resp as Record<string, unknown>).data as unknown[])
+            : []
+      ) as Record<string, unknown>[];
+      const v = items.find((x) => (x.vaultId || x.slug) === slug);
+      if (!v) {
+        throw new GobiError(
+          `Vault "${slug}" not found among vaults you own.`,
+          "VAULT_NOT_FOUND",
+        );
+      }
+
+      const isPublished = v.public === true;
+      const profileUrl = `https://gobispace.com/@${slug}`;
+      const status = {
+        vaultSlug: slug,
+        name: v.name,
+        isPrimary: !!v.isPrimary,
+        isPublished,
+        title: v.title ?? null,
+        description: v.description ?? null,
+        tags: v.tags ?? null,
+        thumbnailPath: v.thumbnailPath ?? null,
+        homepagePath: v.homepagePath ?? null,
+        promptPath: v.promptPath ?? null,
+        totalNumberOfFiles: v.totalNumberOfFiles ?? 0,
+        totalSizeOfFiles: v.totalSizeOfFiles ?? 0,
+        lastUpdatedTime: v.lastUpdatedTime ?? null,
+        profileUrl: isPublished ? profileUrl : null,
+      };
+
+      if (isJsonMode(vault)) {
+        jsonOut(status);
+        return;
+      }
+
+      const lines = [
+        `Vault: [${slug}] ${v.name}${v.isPrimary ? " (primary)" : ""}`,
+        `  Published: ${isPublished ? "yes" : "no"}`,
+      ];
+      if (!isPublished) {
+        lines.push(
+          `  Note: not yet public. Run 'gobi vault publish' to make it discoverable at ${profileUrl}.`,
+        );
+      } else {
+        lines.push(`  URL: ${profileUrl}`);
+      }
+      if (v.title) lines.push(`  Title: ${v.title}`);
+      if (v.description) lines.push(`  Description: ${v.description}`);
+      if (Array.isArray(v.tags) && v.tags.length)
+        lines.push(`  Tags: ${(v.tags as string[]).join(", ")}`);
+      if (v.thumbnailPath) lines.push(`  Thumbnail: ${v.thumbnailPath}`);
+      if (v.homepagePath) lines.push(`  Homepage: ${v.homepagePath}`);
+      if (v.promptPath) lines.push(`  Prompt: ${v.promptPath}`);
+      lines.push(`  Files: ${v.totalNumberOfFiles ?? 0}`);
+      console.log(lines.join("\n"));
+    });
+  requireVault(statusCmd);
+
   const publishCmd = vault
     .command("publish")
     .description(


### PR DESCRIPTION
## Summary
- New `gobi vault status` command — read-only diagnostic returning `isPublished`, profile fields, file count, and the public profile URL. Use as a prerequisite before posting with `--auto-attachments` to catch unpublished vaults whose attachments wouldn't be reachable at `gobispace.com/@…`.
- Documented canonical public link formats (`@vault`, `@vault?postId=…`, `@vault?file=…`, `/spaces/<slug>?postId=…`, `/posts/{id}`) in `gobi-vault` and `gobi-space` skills.
- `gobi-space` skill now instructs callers to run `gobi vault status` before any `--auto-attachments` upload.
- Version bump to 2.0.8 across package.json, plugin.json, marketplace.json, skill SKILL.md, and the cheatsheet.

## Test plan
- [x] Built locally; `gobi vault status` and `gobi --json vault status` verified against a published and an unpublished vault.
- [x] Tag `v2.0.8` pushed; release workflow building/publishing to npm.
- [ ] Confirm Homebrew formula updates after npm tarball lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)