### PR TITLE
Release v2.0.10: /post command, vault file links, CLI restructure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "author": {
     "name": "gobi-ai"
   },

--- a/commands/post.md
+++ b/commands/post.md
@@ -1,0 +1,79 @@
+---
+name: post
+description: Draft a post from recent conversation history and publish it to the spaces it best fits. Default mode requires approval; pass `bypass` to post without confirmation.
+argument-hint: "[approval|bypass]"
+---
+
+Always use the globally installed `gobi` binary (not via npx or ts-node).
+
+## Argument: permissionMode
+
+`$ARGUMENTS` is the permission mode. Accept exactly:
+
+- `approval` (default if `$ARGUMENTS` is empty or unrecognized) — draft, present, and require user confirmation before posting.
+- `bypass` — draft and post without a confirmation step.
+
+Treat anything else as `approval`. Do not ask the user which mode to use — the argument is the answer.
+
+## Pre-flight check
+
+```bash
+gobi --json auth status
+```
+
+If unauthenticated, stop and ask the user to run `/gobi:login`.
+
+## 1. List spaces and choose targets
+
+```bash
+gobi --json space list
+```
+
+Each entry has `slug`, `name`, `description`, and (sometimes) `rules`. If the list is empty, stop — there's nowhere to post.
+
+Review the recent conversation history and extract content that is:
+
+- **Reusable** — others could apply it to their own work.
+- **Generalizable** — patterns, decisions, constraints, discoveries; not a one-off task log.
+- **Not sensitive** — exclude code snippets, file paths, PII, credentials, internal URLs, proprietary details.
+
+Then match the content against each space's `name`, `description`, and `rules`. Pick the **space(s) the content genuinely fits** — could be one, could be a few. If nothing fits, stop and tell the user no space matched; do **not** force a post into a tangentially related space.
+
+If a space's `rules` constrain format, topic, or tone, follow them — or skip that space.
+
+## 2. Draft the post
+
+For each target space, prepare:
+
+- **Title** — short, descriptive, no leading `#`, does not duplicate the body's first line.
+- **Content** — markdown body (2–5 bullets is usually right). Do not repeat the title inside the content. Tailor per space if their rules differ; otherwise the same draft can go to multiple spaces.
+
+## 3. Approval mode (default)
+
+Show the user, for each target space:
+
+- The space slug and name.
+- The exact `gobi space create-post` command that will run.
+- The resolved title and a preview of the content.
+
+Wait for the user's confirmation. Accept redirects ("only post to X", "rewrite the title", "skip space Y") and re-present before posting. Do not post until the user confirms.
+
+## 4. Bypass mode
+
+Skip the confirmation step. Proceed straight to posting. Still print the target space(s) and the command(s) to the terminal so the action is visible.
+
+## 5. Post
+
+For each chosen space, run:
+
+```bash
+gobi space create-post --space-slug <slug> --title "<title>" --content "<content>"
+```
+
+(`--space-slug` overrides `.gobi/settings.yaml`, so this works without `gobi space warp` first.)
+
+After each post, echo the result with a shareable URL built from the response:
+
+`https://gobispace.com/spaces/<spaceSlug>?postId=<id>`
+
+If a post fails, report the error and continue with the remaining targets — one failure should not block the others.

--- a/docs/cheatsheet/build.py
+++ b/docs/cheatsheet/build.py
@@ -187,7 +187,7 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.8</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.9</span></h1>
       <div class="tag">Spaces · Global · Vault · Saved · Sessions · Media</div>
     </div>
     <div class="setup">

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.8</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.9</span></h1>
       <div class="tag">Spaces · Global · Vault · Saved · Sessions · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.8).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.9).
 
 ## Prerequisites
 

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-draft
 
-Gobi draft commands for managing agent-authored drafts (v2.0.8).
+Gobi draft commands for managing agent-authored drafts (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.8).
+Gobi media generation commands (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-saved/SKILL.md
+++ b/skills/gobi-saved/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-saved
 
-Gobi saved-knowledge commands (v2.0.8).
+Gobi saved-knowledge commands (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.8).
+Gobi sense commands for activity and transcription data (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -58,6 +58,7 @@ Once a post is created, you can build a shareable URL from the response:
 - **Personal post without a vault** (created with no `--vault-slug`) — use `https://gobispace.com/posts/{id}` as a direct fallback.
 - **Space post** — `https://gobispace.com/spaces/{spaceSlug}?postId={id}` (overlay on the space feed) or `https://gobispace.com/spaces/{spaceSlug}/posts/{id}` (dedicated page).
 - **Vault profile** — `https://gobispace.com/@{vaultSlug}`.
+- **Vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). First-class URL for linking to a single file from a published vault — renders in the main feed chrome (not the vault homepage). Use this when a post body or reply needs to point readers at a specific vault file. URL-encode each path segment. See **gobi-vault** skill for full semantics.
 
 When you echo a "Post created!" line (or the JSON response is consumed by another agent), include the assembled URL using the fields actually returned (`id`, `authorVaultSlug`, `spaceSlug`) — don't fabricate slugs.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -30,6 +30,7 @@ Anything you can do to a Space Post (reply, edit, delete, attribute to a vault) 
 
 - When the user wants to explore or catch up on what's happening in their space, invoke `/gobi:space-explore`.
 - When the user wants to share or post learnings from the current session, invoke `/gobi:space-share`.
+- When the user wants to draft a post from the current session and route it to whichever space(s) it best fits, invoke `/gobi:post` (default approval mode; pass `bypass` to skip confirmation).
 
 ## Authoring posts: title vs. content
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-space
 
-Gobi space and global posts (v2.0.8).
+Gobi space and global posts (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -48,7 +48,7 @@ Once a vault is published (i.e. `gobi vault status` reports `isPublished: yes`),
 
 - **Vault profile** — `https://gobispace.com/@{vaultSlug}` (e.g. `https://gobispace.com/@jyk`).
 - **Direct link to a personal post on the vault** — `https://gobispace.com/@{vaultSlug}?postId={postId}` (e.g. `https://gobispace.com/@jyk?postId=144869`). Open in the vault profile with that post focused.
-- **Direct link to a vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). This is the first-class URL for sharing a single file from a vault — use it whenever you want a reader to land on one specific file.
+- **Direct link to a vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). This is the first-class URL for sharing a single file from a vault — use it whenever you want a reader to land on one specific file. The page renders inside the main feed chrome (sidebar + header), so readers stay in `gobispace.com` instead of pivoting to the vault homepage. Paths without an extension are treated as markdown (the same wikilink-stem resolution webdrive uses), so `?path=intro` and `?path=intro.md` both resolve. URL-encode each path segment when assembling.
 - **Custom homepage** — when `homepage` is set in `PUBLISH.md` frontmatter, the vault profile URL renders that HTML file. See **gobi-homepage** skill.
 
 When linking back to your own posts or files, assemble the URL from concrete fields (the post's `authorVaultSlug` + `id`, or the vault's `vaultSlug` + the file's path) rather than guessing.

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -48,11 +48,10 @@ Once a vault is published (i.e. `gobi vault status` reports `isPublished: yes`),
 
 - **Vault profile** — `https://gobispace.com/@{vaultSlug}` (e.g. `https://gobispace.com/@jyk`).
 - **Direct link to a personal post on the vault** — `https://gobispace.com/@{vaultSlug}?postId={postId}` (e.g. `https://gobispace.com/@jyk?postId=144869`). Open in the vault profile with that post focused.
-- **Open a vault file in the profile** — `https://gobispace.com/@{vaultSlug}?file={path}` (path is relative to the vault root, e.g. `?file=notes/intro.md`).
-- **Serve a vault HTML file directly with the `window.gobi` bridge injected** — append `&raw=1`: `https://gobispace.com/@{vaultSlug}?file={path}&raw=1`.
+- **Direct link to a vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). This is the first-class URL for sharing a single file from a vault — use it whenever you want a reader to land on one specific file.
 - **Custom homepage** — when `homepage` is set in `PUBLISH.md` frontmatter, the vault profile URL renders that HTML file. See **gobi-homepage** skill.
 
-When linking back to your own posts (e.g. "I wrote about this here: …"), assemble the URL from the post's `authorVaultSlug` and `id` rather than guessing.
+When linking back to your own posts or files, assemble the URL from concrete fields (the post's `authorVaultSlug` + `id`, or the vault's `vaultSlug` + the file's path) rather than guessing.
 
 ## Confirm before mutating
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.8"
+  version: "2.0.9"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.8).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.9).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 


### PR DESCRIPTION
## Summary
- New `/gobi:post` slash command — drafts from session history and routes to space(s) it best fits, with `approval`/`bypass` modes.
- Vault file links: `gobispace.com/file/{slug}?path={path}` is now the canonical share URL for individual vault files; documented across vault and space skills.
- `gobi vault status` command added.
- Migrated saved/global from deprecated `/feed/*` routes to canonical `/posts/*`.
- CLI restructure: dropped `gobi init`, flattened `saved`, renamed `media`/`sense`.
- `gobi space list` human output now includes description and rules.
- Bundles versions 2.0.5 → 2.0.10.

## Test plan
- [ ] `gobi update` to v2.0.10 and verify `gobi --version`
- [ ] `/gobi:post` lists spaces and drafts a relevant post in approval mode
- [ ] `gobi vault status` returns expected publication state
- [ ] Existing workflows (`/gobi:space-share`, `/gobi:space-explore`, `/gobi:warp`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)