### PR TITLE
Release v2.0.12: draft.vaultSlug + create-post --draft-id mutual exclusivity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -28,7 +28,8 @@ A draft is a unit of standing guidance authored by an agent (in-process during c
 - **actions** — 0–3 AI-suggested actions. Each action is `{ label, message? }`:
   - `label` — short button text (1–80 chars) the user sees, e.g. `"Apply"`, `"Skip"`.
   - `message` — optional (≤2000 chars). What the user is taken to be saying to the agent when they click that button. Falls back to `label` when omitted. Use this whenever the click should send something more specific than the button text — e.g. label `"Punch it up"`, message `"Tighten the opening paragraph and shorten the CTA"`.
-- **sessionId** — the chat session the draft is anchored to. Optional on create: when omitted, the server mints a fresh session anchored to the user's primary vault and seeds it with a tool-call entry representing the draft, so clicking an action later has somewhere to land.
+- **sessionId** — the chat session the draft is anchored to. Optional on create: when omitted, the server mints a fresh session anchored to the draft's vault (or the user's primary if `vaultSlug` is unset) and seeds it with a tool-call entry representing the draft, so clicking an action later has somewhere to land.
+- **vaultSlug** — optional anchor vault slug. When set, clients render the draft against this vault's identity and the bootstrap session (created when no `sessionId` is passed) is anchored here instead of the user's primary. Pass `--vault-slug <slug>` on `add` or `revise`. Caller must own the vault.
 - **priority** — lower number = higher priority; default `100`
 - **status** — `pending` until the user picks an action, then `actioned`
 - **revision** — bumped each time the draft is revised
@@ -76,11 +77,12 @@ When the user picks an action via `gobi draft action <id> <index>`, the response
 
 ## Linking a created post back to its draft
 
-When the user picks an action like "Post to Global Feed" / "Post to <space>" and your next turn creates the post, pass `--draft-id <draftId>` to `gobi space create-post` or `gobi global create-post`. The CLI records the resulting `postId` (and `spaceSlug` for space posts) on `draft.metadata`, which the client uses to render an "Open post" button on the actioned draft. Without `--draft-id` the post is still created, but the draft and the post stay disconnected in the UI.
+When the user picks an action like "Post to Global Feed" / "Post to <space>" and your next turn creates the post, pass `--draft-id <draftId>` to `gobi space create-post` or `gobi global create-post`. `--draft-id` is the **sole** source of `title` and `content` for the post — the CLI fetches the draft and uses its title and content directly, so `--title`, `--content`, and `--rich-text` are not allowed alongside it. If you want to change the wording, `gobi draft revise` first, then create the post. The draft's `vaultSlug` (when set) seeds the post's `--vault-slug` if not given explicitly. `--auto-attachments` and `--space-slug` (and an explicit `--vault-slug` override) are still allowed. On success the CLI records `{ postId, spaceSlug? }` on `draft.metadata`, which the client uses to render an "Open post" button on the actioned draft.
 
 ```bash
-gobi --json global create-post --title "..." --content "..." --draft-id <draftId>
-gobi --json space create-post --space-slug <slug> --title "..." --content "..." --draft-id <draftId>
+gobi --json global create-post --draft-id <draftId>
+gobi --json space create-post --space-slug <slug> --draft-id <draftId>
+gobi --json global create-post --draft-id <draftId> --auto-attachments
 ```
 
 ## Available Commands
@@ -88,11 +90,11 @@ gobi --json space create-post --space-slug <slug> --title "..." --content "..." 
 - `gobi draft` — Drafts authored by your agent during chat. Each carries up to 3 AI-suggested actions. Top-5 pending feed the system prompt; picking an action posts a synthesized message into the originating session.
   - `gobi draft list` — List drafts (priority ASC, then newest first).
   - `gobi draft get` — Show one draft with its history and suggested actions.
-  - `gobi draft add` — Add a draft. Pass `--action <label[::message]>` up to 3 times to attach AI-suggested actions.
+  - `gobi draft add` — Add a draft. Pass `--action <label[::message]>` up to 3 times to attach AI-suggested actions. Pass `--vault-slug <slug>` to anchor the draft to a specific vault.
   - `gobi draft delete` — Delete a draft.
   - `gobi draft prioritize` — Set priority (lower = higher). Top 5 feed the system prompt.
   - `gobi draft action` — Take one of the draft's suggested actions by 0-based index. Posts the synthesized message into the originating session.
-  - `gobi draft revise` — Bump the draft to a new revision with a comment, optionally replacing title / content / actions.
+  - `gobi draft revise` — Bump the draft to a new revision with a comment, optionally replacing title / content / actions / vault-slug.
 
 ## Confirm before mutating
 

--- a/skills/gobi-draft/references/draft.md
+++ b/skills/gobi-draft/references/draft.md
@@ -59,6 +59,8 @@ Options:
   --priority <number>          Priority (lower = higher), default 100
   --action <label[::message]>  Suggested action (repeatable, max 3). `label` is the button text; an optional `::message` suffix is what the user is taken to be saying to the agent on click. Without
                                the suffix, the message falls back to the label. (default: [])
+  --vault-slug <vaultSlug>     Anchor vault for this draft. When set, clients render the draft against this vault, and a sessionId-less create bootstraps the new chat session here instead of your
+                               primary vault.
   -h, --help                   display help for command
 ```
 
@@ -107,5 +109,6 @@ Options:
   --title <title>              Replacement title
   --content <content>          Replacement content; pass '-' to read from stdin
   --action <label[::message]>  Replacement suggested action (repeatable, max 3). Same `label[::message]` syntax as `draft add`. When passed, replaces the entire actions array. (default: [])
+  --vault-slug <vaultSlug>     Replacement anchor vault. When set, switches the draft's anchor vault. Carries forward when omitted.
   -h, --help                   display help for command
 ```

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -135,7 +135,7 @@ Posts and replies are publicly visible — in a community space (`gobi space …
 
 ### Linking back to a draft
 
-When a `create-post` is the side-effect of an actioned draft (e.g. the user picked "Post to Global Feed" / "Post to <space>"), pass `--draft-id <draftId>` to `gobi space create-post` or `gobi global create-post`. The CLI records `{ postId, spaceSlug? }` on `draft.metadata`, which the client renders as an "Open post" button on the actioned draft. Without `--draft-id` the post is still created, but the draft and post stay disconnected in the UI.
+When a `create-post` is the side-effect of an actioned draft (e.g. the user picked "Post to Global Feed" / "Post to <space>"), pass `--draft-id <draftId>` to `gobi space create-post` or `gobi global create-post`. `--draft-id` is the **sole** source of `title` and `content` — it cannot coexist with `--title`, `--content`, or `--rich-text`. To change the wording, `gobi draft revise` first, then create the post. The draft's `vaultSlug` (when set) seeds the post's `--vault-slug` if not given explicitly. `--auto-attachments` and an explicit `--vault-slug` override are still allowed. On success the CLI records `{ postId, spaceSlug? }` on `draft.metadata`, which the client renders as an "Open post" button on the actioned draft.
 - `edit-post` / `edit-reply` — confirm the *new* content; people who already saw the original may re-see it.
 - `delete-post` / `delete-reply` — irreversible. Flag that explicitly and confirm the target id before running.
 

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -77,7 +77,8 @@ Options:
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug). Defaults to your primary vault.
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before posting (also sets authorVaultSlug to that vault)
-  --draft-id <draftId>      Link this post back to the draft it was created from (records postId on draft.metadata so the client can render an 'Open post' button).
+  --draft-id <draftId>      Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId on
+                            draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -123,7 +123,8 @@ Options:
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before posting (also attributes the post to that vault)
   --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultId). Also used as upload destination for --auto-attachments.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
-  --draft-id <draftId>      Link this post back to the draft it was created from (records postId/spaceSlug on draft.metadata so the client can render an 'Open post' button).
+  --draft-id <draftId>      Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId/spaceSlug on
+                            draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.
   -h, --help                display help for command
 ```
 

--- a/src/commands/draft.ts
+++ b/src/commands/draft.ts
@@ -32,6 +32,7 @@ interface Draft {
   actions: DraftAction[];
   history: DraftHistoryEvent[];
   status: "pending" | "actioned";
+  vaultSlug: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -124,6 +125,7 @@ export function registerDraftCommand(program: Command): void {
       console.log(`  priority: ${d.priority}`);
       console.log(`  revision: ${d.revision}`);
       console.log(`  session:  ${d.sessionId}`);
+      if (d.vaultSlug) console.log(`  vault:    ${d.vaultSlug}`);
       console.log(`  created:  ${d.createdAt}`);
       console.log("");
       console.log("Content:");
@@ -181,6 +183,10 @@ export function registerDraftCommand(program: Command): void {
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
+    .option(
+      "--vault-slug <vaultSlug>",
+      "Anchor vault for this draft. When set, clients render the draft against this vault, and a sessionId-less create bootstraps the new chat session here instead of your primary vault.",
+    )
     .action(
       async (
         title: string,
@@ -189,6 +195,7 @@ export function registerDraftCommand(program: Command): void {
           session?: string;
           priority?: string;
           action?: string[];
+          vaultSlug?: string;
         },
       ) => {
         const sessionId = opts.session || process.env.GOBI_SESSION_ID;
@@ -200,6 +207,7 @@ export function registerDraftCommand(program: Command): void {
         if (opts.priority) body.priority = parseInt(opts.priority, 10);
         const actions = parseActionFlags(opts.action);
         if (actions.length) body.actions = actions;
+        if (opts.vaultSlug) body.vaultSlug = opts.vaultSlug;
 
         const resp = (await apiPost("/app/drafts", body)) as Record<string, unknown>;
         const d = unwrapResp(resp) as Draft;
@@ -291,6 +299,10 @@ export function registerDraftCommand(program: Command): void {
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
+    .option(
+      "--vault-slug <vaultSlug>",
+      "Replacement anchor vault. When set, switches the draft's anchor vault. Carries forward when omitted.",
+    )
     .action(
       async (
         draftId: string,
@@ -299,6 +311,7 @@ export function registerDraftCommand(program: Command): void {
           title?: string;
           content?: string;
           action?: string[];
+          vaultSlug?: string;
         },
       ) => {
         const body: Record<string, unknown> = {
@@ -309,6 +322,7 @@ export function registerDraftCommand(program: Command): void {
         if (opts.action && opts.action.length > 0) {
           body.actions = parseActionFlags(opts.action);
         }
+        if (opts.vaultSlug !== undefined) body.vaultSlug = opts.vaultSlug;
 
         const resp = (await apiPost(
           `/app/drafts/${draftId}/revise`,

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { apiGet, apiPost, apiPatch, apiDelete } from "../client.js";
 import {
+  fetchDraftSummary,
   isJsonMode,
   jsonOut,
   readStdin,
@@ -236,7 +237,7 @@ export function registerGlobalCommand(program: Command): void {
     )
     .option(
       "--draft-id <draftId>",
-      "Link this post back to the draft it was created from (records postId on draft.metadata so the client can render an 'Open post' button).",
+      "Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId on draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.",
     )
     .action(async (opts: {
       title?: string;
@@ -246,20 +247,34 @@ export function registerGlobalCommand(program: Command): void {
       autoAttachments?: boolean;
       draftId?: string;
     }) => {
-      if (!opts.content && !opts.richText) {
-        throw new Error("Provide either --content or --rich-text.");
+      if (opts.draftId) {
+        if (opts.title || opts.content || opts.richText) {
+          throw new Error(
+            "--draft-id sources title and content from the draft; --title, --content, and --rich-text are not allowed alongside it.",
+          );
+        }
+      } else {
+        if (!opts.content && !opts.richText) {
+          throw new Error("Provide either --content or --rich-text (or --draft-id).");
+        }
+        if (opts.content && opts.richText) {
+          throw new Error("--content and --rich-text are mutually exclusive.");
+        }
       }
-      if (opts.content && opts.richText) {
-        throw new Error("--content and --rich-text are mutually exclusive.");
-      }
+
+      const draft = opts.draftId ? await fetchDraftSummary(opts.draftId) : null;
+      const effectiveTitle = draft ? draft.title : opts.title;
+      const effectiveContent = draft ? draft.content : opts.content;
+      const effectiveVaultSlugOpt = opts.vaultSlug ?? draft?.vaultSlug ?? undefined;
+
       let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug || opts.autoAttachments) {
-        authorVaultSlug = resolveVaultSlug(opts);
+      if (effectiveVaultSlugOpt || opts.autoAttachments) {
+        authorVaultSlug = resolveVaultSlug({ vaultSlug: effectiveVaultSlugOpt });
       }
       const body: Record<string, unknown> = {};
-      if (opts.title != null) body.title = opts.title;
-      if (opts.content != null) {
-        const content = readContent(opts.content);
+      if (effectiveTitle != null) body.title = effectiveTitle;
+      if (effectiveContent != null) {
+        const content = draft ? effectiveContent! : readContent(effectiveContent!);
         if (opts.autoAttachments && authorVaultSlug) {
           const token = await getValidToken();
           const links = extractWikiLinks(content);

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -7,6 +7,7 @@ import {
   writeSpaceSetting,
 } from "./init.js";
 import {
+  fetchDraftSummary,
   isJsonMode,
   jsonOut,
   readStdin,
@@ -414,7 +415,7 @@ export function registerSpaceCommand(program: Command): void {
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--draft-id <draftId>",
-      "Link this post back to the draft it was created from (records postId/spaceSlug on draft.metadata so the client can render an 'Open post' button).",
+      "Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId/spaceSlug on draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.",
     )
     .action(
       async (opts: {
@@ -426,20 +427,34 @@ export function registerSpaceCommand(program: Command): void {
         spaceSlug?: string;
         draftId?: string;
       }) => {
-        if (!opts.content && !opts.richText) {
-          throw new Error("Provide either --content or --rich-text.");
+        if (opts.draftId) {
+          if (opts.title || opts.content || opts.richText) {
+            throw new Error(
+              "--draft-id sources title and content from the draft; --title, --content, and --rich-text are not allowed alongside it.",
+            );
+          }
+        } else {
+          if (!opts.content && !opts.richText) {
+            throw new Error("Provide either --content or --rich-text (or --draft-id).");
+          }
+          if (opts.content && opts.richText) {
+            throw new Error("--content and --rich-text are mutually exclusive.");
+          }
         }
-        if (opts.content && opts.richText) {
-          throw new Error("--content and --rich-text are mutually exclusive.");
-        }
+
+        const draft = opts.draftId ? await fetchDraftSummary(opts.draftId) : null;
+        const effectiveTitle = draft ? draft.title : opts.title;
+        const effectiveContent = draft ? draft.content : opts.content;
+        const effectiveVaultSlugOpt = opts.vaultSlug ?? draft?.vaultSlug ?? undefined;
+
         let authorVaultSlug: string | undefined;
-        if (opts.vaultSlug || opts.autoAttachments) {
-          authorVaultSlug = resolveVaultSlug(opts);
+        if (effectiveVaultSlugOpt || opts.autoAttachments) {
+          authorVaultSlug = resolveVaultSlug({ vaultSlug: effectiveVaultSlugOpt });
         }
         const body: Record<string, unknown> = {};
-        if (opts.title != null) body.title = opts.title;
-        if (opts.content != null) {
-          const content = readContent(opts.content);
+        if (effectiveTitle != null) body.title = effectiveTitle;
+        if (effectiveContent != null) {
+          const content = draft ? effectiveContent! : readContent(effectiveContent!);
           if (opts.autoAttachments) {
             const token = await getValidToken();
             const links = extractWikiLinks(content);

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -1,6 +1,29 @@
 import { readFileSync } from "fs";
 import { Command } from "commander";
+import { apiGet } from "../client.js";
 import { getSpaceSlug, getVaultSlug } from "./init.js";
+
+export interface DraftSummary {
+  draftId: string;
+  title: string;
+  content: string;
+  vaultSlug: string | null;
+}
+
+// Fetch a draft and return just the fields a post-creation flow needs. Used
+// by `space create-post` and `global create-post` when --draft-id is passed:
+// title/content come from the draft, vaultSlug seeds the post's authorship
+// when the caller did not pass --vault-slug.
+export async function fetchDraftSummary(draftId: string): Promise<DraftSummary> {
+  const resp = (await apiGet(`/app/drafts/${draftId}`)) as Record<string, unknown>;
+  const data = unwrapResp(resp) as Record<string, unknown>;
+  return {
+    draftId: String(data.draftId ?? draftId),
+    title: String(data.title ?? ""),
+    content: String(data.content ?? ""),
+    vaultSlug: (data.vaultSlug as string | null | undefined) ?? null,
+  };
+}
 
 // Reads all of stdin synchronously. Uses fd 0 (cross-platform) instead of
 // "/dev/stdin", which doesn't exist on Windows.


### PR DESCRIPTION
## Summary
- `gobi draft add` and `gobi draft revise` accept optional `--vault-slug <slug>`. When set, the draft carries an anchor vault — clients render the draft against that vault's identity, and a sessionId-less create bootstraps the new chat session there instead of the user's primary.
- `gobi space create-post` and `gobi global create-post`: `--draft-id` is now mutually exclusive with `--title`/`--content`/`--rich-text`. The CLI fetches the draft and uses its title/content directly. The draft's `vaultSlug` (when set) seeds `--vault-slug` if not given explicitly. `--auto-attachments`, `--space-slug`, and explicit `--vault-slug` overrides remain allowed.
- gobi-draft and gobi-space skill docs updated; references regenerated.
- Version bump: 2.0.12 across package.json, marketplace.json, plugin.json.

Requires the matching gobi-backend change (`drafts.vault_slug` column + DTO/service updates) for `--vault-slug` on draft endpoints to be accepted by the API.

## Test plan
- [ ] `gobi --version` reports 2.0.12 after install
- [ ] `gobi space create-post --draft-id <id> --title "x"` errors with the mutual-exclusivity message
- [ ] `gobi space create-post --draft-id <id>` posts using the draft's title/content
- [ ] `gobi space create-post --draft-id <id> --auto-attachments` uploads wiki-linked files and posts (vault sourced from draft.vaultSlug or `.gobi`)
- [ ] After backend deploys: `gobi draft add "t" "c" --vault-slug <slug>` succeeds and `gobi draft get <id>` shows `vault: <slug>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)