### PR TITLE
gobi-media SKILL.md: drop `create-reply --attach` post-mention guidance, write text only

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, manage saved notes and posts, manage sessions, generate images and videos.",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "author": {
     "name": "gobi-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -77,12 +77,16 @@ When the user picks an action via `gobi draft action <id> <index>`, the response
 
 ## Linking a created post back to its draft
 
-When the user picks an action like "Post to Global Feed" / "Post to <space>" and your next turn creates the post, pass `--draft-id <draftId>` to `gobi space create-post` or `gobi global create-post`. `--draft-id` is the **sole** source of `title` and `content` for the post — the CLI fetches the draft and uses its title and content directly, so `--title`, `--content`, and `--rich-text` are not allowed alongside it. If you want to change the wording, `gobi draft revise` first, then create the post. The draft's `vaultSlug` (when set) seeds the post's `--vault-slug` if not given explicitly. `--auto-attachments` and `--space-slug` (and an explicit `--vault-slug` override) are still allowed. On success the CLI records `{ postId, spaceSlug? }` on `draft.metadata`, which the client uses to render an "Open post" button on the actioned draft.
+When the user picks an action like "Post to Global Feed" / "Post to <space>" / "Save as note" and your next turn creates the post or note, pass `--draft-id <draftId>` to the relevant create command. `--draft-id` is the **sole** source of `title` and `content` — the CLI fetches the draft and uses its title and content directly, so `--title` / `--content` / `--rich-text` are not allowed alongside it on `create-post`, and `--content` is not allowed alongside it on `create-note`. If you want to change the wording, `gobi draft revise` first, then create.
+
+- `gobi space create-post --draft-id` / `gobi global create-post --draft-id` — uses draft's title and content as the post's `title` and `content`. The draft's `vaultSlug` (when set) seeds `--vault-slug` if not given explicitly. `--auto-attachments`, `--space-slug`, and an explicit `--vault-slug` override remain allowed. Records `{ postId, spaceSlug? }` on `draft.metadata` for an "Open post" button.
+- `gobi saved create-note --draft-id` — fetches the draft and folds it into the note as `# <title>\n\n<content>` (or just content when title is empty). Records `{ noteId }` on `draft.metadata` for an "Open note" button.
 
 ```bash
 gobi --json global create-post --draft-id <draftId>
 gobi --json space create-post --space-slug <slug> --draft-id <draftId>
 gobi --json global create-post --draft-id <draftId> --auto-attachments
+gobi --json saved create-note --draft-id <draftId>
 ```
 
 ## Available Commands

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -40,25 +40,24 @@ Replace `<RATIO>` with the desired aspect ratio: `1:1`, `16:9`, `9:16`, `4:3`, o
 
 The `-o` flag implies `--wait` and downloads the image when done.
 
-**Where you reference the downloaded file depends on what you're doing with it:**
+**Where you reference the downloaded file depends on the surface you're rendering to:**
 
 - **Chat / vault note (vault is mounted, ![[wikilinks]] resolve):** use Obsidian wiki-link syntax:
   ```
   ![[media/<NAME>.png]]
   ```
-- **Post or reply (any flow that goes through `gobi <scope> create-post` or `gobi <scope> create-reply`):** do NOT embed the image in `--content`. Pass the file as a first-class attachment:
+- **Post or reply you're authoring with the CLI** (`gobi <scope> create-post` / `create-reply`): do NOT embed the image in `--content`. Pass the file as a first-class attachment:
   ```bash
   gobi space create-post --title "<TITLE>" --content "<BODY>" --attach media/<NAME>.png
   gobi space create-reply <postId> --content "<BODY>" --attach media/<NAME>.png
   ```
-  This uploads the file to the CDN and renders it as a slider on the post card. The `--attach` flag is repeatable; mix rule is **4 photos OR 1 GIF OR 1 video**.
-
-  In particular, when you're answering a post-mention (`@gobi` / `@space:<slug>` on a thread) and need to send media, **call `gobi <scope> create-reply <postId> --attach <file>` yourself** — your text-only assistant body is auto-posted only if you don't call create-reply this turn, so calling it explicitly is the only way to land media on the thread.
+  This uploads to the CDN and renders the image as a slider on the post card. `--attach` is repeatable; mix rule is **4 photos OR 1 GIF OR 1 video**.
+- **Post-mention reply** (you were `@`-mentioned on a thread — `@gobi` / `@space:<slug>` — and your assistant body is auto-posted as the reply): **just write the text reply. Do not include the image as wiki-link, markdown image, or any URL.** The runtime detects every `gobi media generate-image` call you ran this turn and attaches those images to your auto-posted reply automatically. Embedding the image yourself either dangles (the workspace path doesn't resolve publicly) or duplicates the slider.
 
 ### Key rules
 - Replace `<NAME>` with a descriptive slug — NEVER use example names like `sunset.png` literally.
 - `--name` is **optional** — auto-derived from prompt if omitted.
-- Do NOT use the `downloadUrl` from the response — it is a Miraflow-internal path, not a public link. Always download with `-o` then either wiki-link (chat/vault) or `--attach` (post/reply).
+- Do NOT use the `downloadUrl` from the response — it is a Miraflow-internal path, not a public link. Always download with `-o` then either wiki-link (chat/vault), `--attach` (CLI-authored post/reply), or nothing (post-mention auto-post — the runtime attaches).
 - `download-image` takes a **positional** jobId (NOT `--job-id`): `gobi media download-image <jobId>`
 - The `jobId` (or `id`) field is what you pass to `download-image` / `get-image-status` — NOT `mediaId`.
 

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -40,18 +40,25 @@ Replace `<RATIO>` with the desired aspect ratio: `1:1`, `16:9`, `9:16`, `4:3`, o
 
 The `-o` flag implies `--wait` and downloads the image when done.
 
-**IMPORTANT: After downloading, show the image using Obsidian wiki-link syntax EXACTLY like this:**
+**Where you reference the downloaded file depends on what you're doing with it:**
 
-```
-![[media/<NAME>.png]]
-```
+- **Chat / vault note (vault is mounted, ![[wikilinks]] resolve):** use Obsidian wiki-link syntax:
+  ```
+  ![[media/<NAME>.png]]
+  ```
+- **Post or reply (any flow that goes through `gobi <scope> create-post` or `gobi <scope> create-reply`):** do NOT embed the image in `--content`. Pass the file as a first-class attachment:
+  ```bash
+  gobi space create-post --title "<TITLE>" --content "<BODY>" --attach media/<NAME>.png
+  gobi space create-reply <postId> --content "<BODY>" --attach media/<NAME>.png
+  ```
+  This uploads the file to the CDN and renders it as a slider on the post card. The `--attach` flag is repeatable; mix rule is **4 photos OR 1 GIF OR 1 video**.
 
-Do NOT use markdown image syntax `![](...)` or `gobi://` URLs. Always use `![[media/<NAME>.png]]`.
+  In particular, when you're answering a post-mention (`@gobi` / `@space:<slug>` on a thread) and need to send media, **call `gobi <scope> create-reply <postId> --attach <file>` yourself** — your text-only assistant body is auto-posted only if you don't call create-reply this turn, so calling it explicitly is the only way to land media on the thread.
 
 ### Key rules
 - Replace `<NAME>` with a descriptive slug — NEVER use example names like `sunset.png` literally.
 - `--name` is **optional** — auto-derived from prompt if omitted.
-- Do NOT use the `downloadUrl` from the response — it is a frontend path, not a direct download link.
+- Do NOT use the `downloadUrl` from the response — it is a Miraflow-internal path, not a public link. Always download with `-o` then either wiki-link (chat/vault) or `--attach` (post/reply).
 - `download-image` takes a **positional** jobId (NOT `--job-id`): `gobi media download-image <jobId>`
 - The `jobId` (or `id`) field is what you pass to `download-image` / `get-image-status` — NOT `mediaId`.
 
@@ -133,7 +140,7 @@ gobi --json media get-avatar-job-status <jobId> --wait
 ![[media/<NAME>.mp4]]
 ```
 
-Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs. Always use `![[media/<NAME>.mp4]]`.
+Do NOT use markdown image/link syntax `![](...)` or `gobi://` URLs in chat. For posts/replies use `--attach media/<NAME>.mp4` instead — see the image workflow above for details.
 
 ## Available Commands
 

--- a/skills/gobi-saved/SKILL.md
+++ b/skills/gobi-saved/SKILL.md
@@ -45,7 +45,7 @@ gobi --json saved list-notes --date 2026-04-27
 ### Notes
 - `gobi saved list-notes` — List your notes. Without `--date`, returns recent notes via cursor pagination. With `--date YYYY-MM-DD`, returns all notes for that day.
 - `gobi saved get-note <noteId>` — Get a single note by id.
-- `gobi saved create-note --content <md>` — Create a note. Use `'-'` for stdin.
+- `gobi saved create-note --content <md>` — Create a note. Use `'-'` for stdin. Or pass `--draft-id <draftId>` to source content from a draft (mutually exclusive with `--content`); the draft's title is prepended as an H1, and the resulting `noteId` is recorded on `draft.metadata` so the client can render an "Open note" button.
 - `gobi saved edit-note <noteId>` — Edit a note. Provide `--content` and/or `--agent-id`.
 - `gobi saved delete-note <noteId>` — Delete a note you authored.
 

--- a/skills/gobi-saved/references/saved.md
+++ b/skills/gobi-saved/references/saved.md
@@ -11,7 +11,7 @@ Options:
 Commands:
   list-notes [options]          List your notes. Without --date, returns recent notes via cursor pagination. With --date, returns all notes for that day.
   get-note <noteId>             Get a single note by id.
-  create-note [options]         Create a note. Provide --content (use '-' for stdin) and/or attachments.
+  create-note [options]         Create a note. Provide --content (use '-' for stdin), or --draft-id to source content from a draft.
   edit-note [options] <noteId>  Edit a note. Provide --content and/or --agent-id.
   delete-note <noteId>          Delete a note you authored.
   list-posts [options]          List posts you have bookmarked (paginated).
@@ -52,13 +52,15 @@ Options:
 ```
 Usage: gobi saved create-note [options]
 
-Create a note. Provide --content (use '-' for stdin) and/or attachments.
+Create a note. Provide --content (use '-' for stdin), or --draft-id to source content from a draft.
 
 Options:
-  --content <content>  Note content (markdown supported, use "-" for stdin)
-  --timezone <tz>      IANA timezone name (default: system timezone)
-  --agent-id <number>  Optional agent id to associate with the note
-  -h, --help           display help for command
+  --content <content>   Note content (markdown supported, use "-" for stdin)
+  --timezone <tz>       IANA timezone name (default: system timezone)
+  --agent-id <number>   Optional agent id to associate with the note
+  --draft-id <draftId>  Use this draft as the source of content (mutually exclusive with --content). The draft's title is prepended as an H1 heading. On success, links the note back by recording
+                        noteId on draft.metadata so the client can render an 'Open note' button.
+  -h, --help            display help for command
 ```
 
 ## edit-note

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -51,6 +51,14 @@ Both `gobi space create-post` / `edit-post` and `gobi global create-post` / `edi
 
 > **Before using `--auto-attachments`, check that the target vault is published.** Run `gobi --json vault status` (or `gobi vault status --vault-slug <slug>`) and verify `isPublished: true`. Files uploaded to a non-public vault are stored on webdrive but are not reachable at `gobispace.com/@{vaultSlug}` — readers will see broken `[[wikilinks]]`. If the status reports unpublished, ask the user to run `gobi vault publish` first (it requires `title` and `description` in `PUBLISH.md`). See the **gobi-vault** skill.
 
+## Post media attachments (`--attach`)
+
+Separate from `--auto-attachments`, `gobi space create-post` and `gobi global create-post` accept `--attach <file>` (repeatable) for inline post media — the photos/GIF/video that render in-feed alongside the post body. The CLI uploads each file to S3 via `POST /posts/upload-url` and passes the resulting `{ mediaUrl, mediaKey }` array as the post's `attachments`.
+
+X-style mix rule (enforced client-side before upload): up to **4 photos** OR **1 GIF** OR **1 video** — they don't combine. Server-side ceilings: 5MB photos, 15MB GIFs, 512MB video.
+
+Use `--attach` for media you want shown in the post itself; use `--auto-attachments` for `[[wikilinks]]` to vault files referenced in the body.
+
 ## Public link formats
 
 Once a post is created, you can build a shareable URL from the response:

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -122,6 +122,8 @@ Options:
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug). Also used as upload destination for --auto-attachments.
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before posting (also attributes the reply to that vault)
+  --attach <file>           Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
+                            [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -79,6 +79,7 @@ Options:
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before posting (also sets authorVaultSlug to that vault)
   --draft-id <draftId>      Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId on
                             draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.
+  --attach <file>           Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -171,6 +171,8 @@ Options:
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before posting (also attributes the reply to that vault)
   --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug). Also used as upload destination for --auto-attachments.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
+  --attach <file>           Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
+                            [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -125,6 +125,7 @@ Options:
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
   --draft-id <draftId>      Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId/spaceSlug on
                             draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.
+  --attach <file>           Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -38,6 +38,10 @@ gobi --json vault publish
 - `gobi vault init` — Interactive: select an existing vault or create a new one. Writes `vaultSlug` to `.gobi/settings.yaml` in the current directory and seeds `PUBLISH.md`. Requires the user to be logged in (`gobi auth login`).
 - `gobi vault list` — List vaults you own. The primary vault is marked.
 - `gobi vault status` — Show the configured vault's publish state (`isPublished`), profile fields (`title`, `description`, `tags`), referenced files (`thumbnailPath`, `homepagePath`, `promptPath`), file count, and the public profile URL. Use this as a diagnostic before posting with `--auto-attachments` (see gobi-space skill) to confirm the vault is public — files uploaded to a non-public vault are stored on webdrive but are not visible at `gobispace.com/@{vaultSlug}` until you run `gobi vault publish`.
+- `gobi vault create <slug> --name <name>` — Create a new vault with the given slug and display name. Slug must be unique (use `vault list` to see what's taken). Does not change the configured vault — run `vault init` here or `vault set-primary <slug>` afterwards if you want to anchor to it.
+- `gobi vault rename <newName>` — Rename the configured vault's display name. Pass `--vault-slug <slug>` to target another vault. Local handle only — the public profile title comes from `PUBLISH.md` frontmatter and is unaffected.
+- `gobi vault set-primary <slug>` — Mark a vault as your primary. Unsets primary on the others. Required arg, no `.gobi` fallback (avoids accidental promotion).
+- `gobi vault delete <slug>` — Delete a vault. Irreversible. Required arg, no `.gobi` fallback. The API will reject if the vault still owns content; clean up posts, members, and files first.
 - `gobi vault publish` — Upload `PUBLISH.md` to the vault root on webdrive. Triggers post-processing (vault profile sync, metadata update, Discord notification).
 - `gobi vault unpublish` — Delete `PUBLISH.md` from the vault on webdrive.
 - `gobi vault sync` — Sync local vault files with Gobi Webdrive. Supports `--upload-only`, `--download-only`, `--conflict <ask|server|client|skip>`, `--dry-run`, `--full`, `--path <p>`, `--plan-file`, `--execute`.
@@ -60,6 +64,9 @@ Every command in this skill writes external state — webdrive files, the public
 - `vault publish` — public profile change + Discord ping. Always confirm.
 - `vault unpublish` — removes the live profile. Always confirm.
 - `vault sync` — can overwrite remote or local files. Run `--dry-run` first and show the user the plan before re-running without `--dry-run`. With `--conflict server` or `--conflict client`, name which side is going to be overwritten.
+- `vault delete <slug>` — irreversible; cannot undo. Confirm the slug and that the user actually means to delete *that* vault before running.
+- `vault set-primary <slug>` — flips which vault is treated as primary across the user's account. Confirm the target.
+- `vault create` / `vault rename` — creating spends a slug permanently; renaming is reversible but visible. Show the user the resolved slug + name before running.
 
 ## PUBLISH.md Frontmatter Reference
 

--- a/skills/gobi-vault/references/vault.md
+++ b/skills/gobi-vault/references/vault.md
@@ -6,16 +6,23 @@ Usage: gobi vault [options] [command]
 Vault commands (init, list, publish/unpublish profile, sync files).
 
 Options:
-  -h, --help        display help for command
+  -h, --help                  display help for command
 
 Commands:
-  init              Select or create the vault for the current directory. Writes .gobi/settings.yaml and seeds PUBLISH.md.
-  list              List vaults you own.
-  status [options]  Show the configured vault's publish state and metadata (use before posting with --auto-attachments to confirm the vault is public).
-  publish           Upload PUBLISH.md to the vault root on webdrive. Triggers post-processing (vault sync, metadata update, Discord notification).
-  unpublish         Delete PUBLISH.md from the vault on webdrive.
-  sync [options]    Sync local vault files with Gobi Webdrive.
-  help [command]    display help for command
+  init                        Select or create the vault for the current directory. Writes .gobi/settings.yaml and seeds PUBLISH.md.
+  create [options] <slug>     Create a new vault. <slug> must be unique (use 'gobi vault list' to see existing slugs); --name sets the display name. Does not change the configured vault — run 'gobi
+                              vault init' or 'gobi vault set-primary' afterwards if you want to anchor to it.
+  rename [options] <newName>  Rename a vault. Defaults to the configured vault (.gobi/settings.yaml); pass --vault-slug to target another. Does not affect PUBLISH.md frontmatter (which controls the
+                              public profile title) — this is the local display name only.
+  delete <slug>               Delete a vault. Irreversible. Slug must be passed explicitly (no .gobi fallback). The API will reject if the vault still owns content; clean up posts, members, and files
+                              first.
+  set-primary <slug>          Mark a vault as your primary. Unsets primary on the other vaults you own. Slug must be passed explicitly.
+  list                        List vaults you own.
+  status [options]            Show the configured vault's publish state and metadata (use before posting with --auto-attachments to confirm the vault is public).
+  publish                     Upload PUBLISH.md to the vault root on webdrive. Triggers post-processing (vault sync, metadata update, Discord notification).
+  unpublish                   Delete PUBLISH.md from the vault on webdrive.
+  sync [options]              Sync local vault files with Gobi Webdrive.
+  help [command]              display help for command
 ```
 
 ## init
@@ -24,6 +31,54 @@ Commands:
 Usage: gobi vault init [options]
 
 Select or create the vault for the current directory. Writes .gobi/settings.yaml and seeds PUBLISH.md.
+
+Options:
+  -h, --help  display help for command
+```
+
+## create
+
+```
+Usage: gobi vault create [options] <slug>
+
+Create a new vault. <slug> must be unique (use 'gobi vault list' to see existing slugs); --name sets the display name. Does not change the configured vault — run 'gobi vault init' or 'gobi vault
+set-primary' afterwards if you want to anchor to it.
+
+Options:
+  --name <name>  Display name for the new vault
+  -h, --help     display help for command
+```
+
+## rename
+
+```
+Usage: gobi vault rename [options] <newName>
+
+Rename a vault. Defaults to the configured vault (.gobi/settings.yaml); pass --vault-slug to target another. Does not affect PUBLISH.md frontmatter (which controls the public profile title) — this is
+the local display name only.
+
+Options:
+  --vault-slug <vaultSlug>  Vault slug to rename (defaults to .gobi/settings.yaml)
+  -h, --help                display help for command
+```
+
+## delete
+
+```
+Usage: gobi vault delete [options] <slug>
+
+Delete a vault. Irreversible. Slug must be passed explicitly (no .gobi fallback). The API will reject if the vault still owns content; clean up posts, members, and files first.
+
+Options:
+  -h, --help  display help for command
+```
+
+## set-primary
+
+```
+Usage: gobi vault set-primary [options] <slug>
+
+Mark a vault as your primary. Unsets primary on the other vaults you own. Slug must be passed explicitly.
 
 Options:
   -h, --help  display help for command

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,8 +1,109 @@
-import { existsSync, readFileSync, appendFileSync } from "fs";
+import { existsSync, readFileSync, appendFileSync, statSync } from "fs";
 import { EOL } from "os";
-import { join, extname } from "path";
+import { basename, join, extname, isAbsolute, resolve } from "path";
 import ignore from "ignore";
 import { WEBDRIVE_BASE_URL } from "./constants.js";
+import { apiPost } from "./client.js";
+
+// Best-effort extension → MIME mapping. Anything we don't recognize falls
+// back to `application/octet-stream`; the backend caps size per content-type
+// tier (5MB photos / 15MB GIFs / 512MB video) so it's the authority on what's
+// allowed. We're just trying to set a usable Content-Type for the S3 PUT.
+const POST_MEDIA_MIME_MAP: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".tiff": "image/tiff",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".m4v": "video/x-m4v",
+  ".pdf": "application/pdf",
+};
+
+export type PostAttachment = { mediaUrl: string; mediaKey: string };
+
+// X-style cap: 4 photos OR 1 GIF OR 1 video. Anything not photo/gif/video
+// is treated as "photo" for cap purposes so misclassified files still get
+// the 4-cap rather than slipping through unlimited.
+export function assertPostAttachmentMix(paths: string[]): void {
+  let photos = 0;
+  let gifs = 0;
+  let videos = 0;
+  for (const p of paths) {
+    const ext = extname(p).toLowerCase();
+    if (ext === ".gif") gifs += 1;
+    else if ([".mp4", ".mov", ".webm", ".m4v"].includes(ext)) videos += 1;
+    else photos += 1;
+  }
+  if (videos > 1) throw new Error("Only 1 video allowed per post");
+  if (gifs > 1) throw new Error("Only 1 GIF allowed per post");
+  if (photos > 4) throw new Error("Up to 4 photos allowed per post");
+  if (videos > 0 && (gifs > 0 || photos > 0)) {
+    throw new Error("A video can't be combined with other media");
+  }
+  if (gifs > 0 && (videos > 0 || photos > 0)) {
+    throw new Error("A GIF can't be combined with other media");
+  }
+}
+
+/**
+ * Upload a single local file as a post attachment.
+ * init (`POST /posts/upload-url`) → PUT to S3 → return `{ mediaUrl, mediaKey }`
+ * suitable for the `attachments` array on create-post.
+ */
+export async function uploadPostAttachment(
+  filePath: string,
+): Promise<PostAttachment> {
+  const abs = isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath);
+  if (!existsSync(abs)) {
+    throw new Error(`Attachment not found: ${filePath}`);
+  }
+  const ext = extname(abs).toLowerCase();
+  const contentType = POST_MEDIA_MIME_MAP[ext] || "application/octet-stream";
+  const fileSize = statSync(abs).size;
+  const initResp = (await apiPost("/posts/upload-url", {
+    fileName: basename(abs),
+    contentType,
+    fileSize,
+  })) as Record<string, unknown>;
+  const data = (initResp.data ?? initResp) as Record<string, unknown>;
+  const uploadUrl = data.uploadUrl as string | undefined;
+  const mediaUrl = data.mediaUrl as string | undefined;
+  const mediaKey = data.mediaKey as string | undefined;
+  if (!uploadUrl || !mediaUrl || !mediaKey) {
+    throw new Error("Upload init returned an incomplete payload");
+  }
+  const body = readFileSync(abs);
+  const putRes = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+  if (!putRes.ok) {
+    throw new Error(
+      `Failed to PUT ${filePath} to S3: HTTP ${putRes.status}`,
+    );
+  }
+  return { mediaUrl, mediaKey };
+}
+
+export async function uploadPostAttachments(
+  paths: string[],
+): Promise<PostAttachment[]> {
+  const out: PostAttachment[] = [];
+  for (const p of paths) {
+    out.push(await uploadPostAttachment(p));
+  }
+  return out;
+}
 
 export function extractWikiLinks(content: string): string[] {
   const seen = new Set<string>();

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -8,7 +8,12 @@ import {
   resolveVaultSlug,
   unwrapResp,
 } from "./utils.js";
-import { extractWikiLinks, uploadAttachments } from "../attachments.js";
+import {
+  extractWikiLinks,
+  uploadAttachments,
+  uploadPostAttachments,
+  assertPostAttachmentMix,
+} from "../attachments.js";
 import { getValidToken } from "../auth/manager.js";
 
 function readContent(value: string): string {
@@ -239,6 +244,12 @@ export function registerGlobalCommand(program: Command): void {
       "--draft-id <draftId>",
       "Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId on draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.",
     )
+    .option(
+      "--attach <file>",
+      "Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
     .action(async (opts: {
       title?: string;
       content?: string;
@@ -246,6 +257,7 @@ export function registerGlobalCommand(program: Command): void {
       vaultSlug?: string;
       autoAttachments?: boolean;
       draftId?: string;
+      attach?: string[];
     }) => {
       if (opts.draftId) {
         if (opts.title || opts.content || opts.richText) {
@@ -292,6 +304,10 @@ export function registerGlobalCommand(program: Command): void {
         body.richText = parsed;
       }
       if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+      if (opts.attach && opts.attach.length > 0) {
+        assertPostAttachmentMix(opts.attach);
+        body.attachments = await uploadPostAttachments(opts.attach);
+      }
       const resp = (await apiPost(`/posts`, body)) as Record<string, unknown>;
       const post = unwrapResp(resp) as Record<string, unknown>;
 

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -451,7 +451,13 @@ export function registerGlobalCommand(program: Command): void {
       "--auto-attachments",
       "Upload wiki-linked [[files]] to webdrive before posting (also attributes the reply to that vault)",
     )
-    .action(async (postId: string, opts: { content?: string; richText?: string; vaultSlug?: string; autoAttachments?: boolean }) => {
+    .option(
+      "--attach <file>",
+      "Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
+    .action(async (postId: string, opts: { content?: string; richText?: string; vaultSlug?: string; autoAttachments?: boolean; attach?: string[] }) => {
       if (!opts.content && !opts.richText) {
         throw new Error("Provide either --content or --rich-text.");
       }
@@ -482,6 +488,10 @@ export function registerGlobalCommand(program: Command): void {
         body.richText = parsed;
       }
       if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+      if (opts.attach && opts.attach.length > 0) {
+        assertPostAttachmentMix(opts.attach);
+        body.attachments = await uploadPostAttachments(opts.attach);
+      }
       const resp = (await apiPost(`/posts/${postId}/replies`, body)) as Record<
         string,
         unknown

--- a/src/commands/saved.ts
+++ b/src/commands/saved.ts
@@ -1,6 +1,12 @@
 import { Command } from "commander";
 import { apiGet, apiPost, apiPatch, apiDelete } from "../client.js";
-import { isJsonMode, jsonOut, readStdin, unwrapResp } from "./utils.js";
+import {
+  fetchDraftSummary,
+  isJsonMode,
+  jsonOut,
+  readStdin,
+  unwrapResp,
+} from "./utils.js";
 
 function defaultTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -116,20 +122,43 @@ export function registerSavedCommand(program: Command): void {
 
   saved
     .command("create-note")
-    .description("Create a note. Provide --content (use '-' for stdin) and/or attachments.")
+    .description("Create a note. Provide --content (use '-' for stdin), or --draft-id to source content from a draft.")
     .option(
       "--content <content>",
       'Note content (markdown supported, use "-" for stdin)',
     )
     .option("--timezone <tz>", "IANA timezone name (default: system timezone)")
     .option("--agent-id <number>", "Optional agent id to associate with the note")
+    .option(
+      "--draft-id <draftId>",
+      "Use this draft as the source of content (mutually exclusive with --content). The draft's title is prepended as an H1 heading. On success, links the note back by recording noteId on draft.metadata so the client can render an 'Open note' button.",
+    )
     .action(
-      async (opts: { content?: string; timezone?: string; agentId?: string }) => {
-        if (!opts.content) {
-          throw new Error("--content is required (use '-' to read from stdin)");
+      async (opts: {
+        content?: string;
+        timezone?: string;
+        agentId?: string;
+        draftId?: string;
+      }) => {
+        if (opts.draftId) {
+          if (opts.content) {
+            throw new Error(
+              "--draft-id sources content from the draft; --content is not allowed alongside it.",
+            );
+          }
+        } else if (!opts.content) {
+          throw new Error("--content is required (use '-' to read from stdin), or pass --draft-id.");
         }
-        const content =
-          opts.content === "-" ? readStdin() : opts.content;
+
+        let content: string;
+        if (opts.draftId) {
+          const draft = await fetchDraftSummary(opts.draftId);
+          content = draft.title
+            ? `# ${draft.title}\n\n${draft.content}`
+            : draft.content;
+        } else {
+          content = opts.content === "-" ? readStdin() : opts.content!;
+        }
 
         const body: Record<string, unknown> = {
           content,
@@ -140,13 +169,24 @@ export function registerSavedCommand(program: Command): void {
         const resp = (await apiPost(`/app/notes`, body)) as Record<string, unknown>;
         const note = unwrapResp(resp) as Record<string, unknown>;
 
+        if (opts.draftId && note.id != null) {
+          try {
+            await apiPatch(`/app/drafts/${opts.draftId}/metadata`, {
+              noteId: typeof note.id === "number" ? note.id : Number(note.id),
+            });
+          } catch (e) {
+            console.error(`Warning: failed to link note to draft ${opts.draftId}: ${(e as Error).message}`);
+          }
+        }
+
         if (isJsonMode(saved)) {
           jsonOut(note);
           return;
         }
 
         console.log(
-          `Note created!\n  ID: ${note.id}\n  Date: ${note.eventDate}\n  Created: ${note.createdAt}`,
+          `Note created!\n  ID: ${note.id}\n  Date: ${note.eventDate}\n  Created: ${note.createdAt}` +
+            (opts.draftId ? `\n  Linked to draft: ${opts.draftId}` : ""),
         );
       },
     );

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -644,7 +644,13 @@ export function registerSpaceCommand(program: Command): void {
       "Attribute the reply to this vault (sets authorVaultSlug). Also used as upload destination for --auto-attachments.",
     )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
-    .action(async (postId: string, opts: { content?: string; richText?: string; autoAttachments?: boolean; vaultSlug?: string; spaceSlug?: string }) => {
+    .option(
+      "--attach <file>",
+      "Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
+    .action(async (postId: string, opts: { content?: string; richText?: string; autoAttachments?: boolean; vaultSlug?: string; spaceSlug?: string; attach?: string[] }) => {
       if (!opts.content && !opts.richText) {
         throw new Error("Provide either --content or --rich-text.");
       }
@@ -675,6 +681,10 @@ export function registerSpaceCommand(program: Command): void {
         body.richText = parsed;
       }
       if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+      if (opts.attach && opts.attach.length > 0) {
+        assertPostAttachmentMix(opts.attach);
+        body.attachments = await uploadPostAttachments(opts.attach);
+      }
       const spaceSlug = resolveSpaceSlug(space, opts);
       const resp = (await apiPost(
         `/spaces/${spaceSlug}/posts/${postId}/replies`,

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -15,7 +15,12 @@ import {
   resolveVaultSlug,
   unwrapResp,
 } from "./utils.js";
-import { extractWikiLinks, uploadAttachments } from "../attachments.js";
+import {
+  extractWikiLinks,
+  uploadAttachments,
+  uploadPostAttachments,
+  assertPostAttachmentMix,
+} from "../attachments.js";
 import { getValidToken } from "../auth/manager.js";
 
 function readContent(value: string): string {
@@ -417,6 +422,12 @@ export function registerSpaceCommand(program: Command): void {
       "--draft-id <draftId>",
       "Use this draft as the source of title and content (mutually exclusive with --title/--content/--rich-text). On success, links the post back by recording postId/spaceSlug on draft.metadata so the client can render an 'Open post' button. The draft's vaultSlug seeds --vault-slug when not given explicitly.",
     )
+    .option(
+      "--attach <file>",
+      "Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
     .action(
       async (opts: {
         title?: string;
@@ -426,6 +437,7 @@ export function registerSpaceCommand(program: Command): void {
         vaultSlug?: string;
         spaceSlug?: string;
         draftId?: string;
+        attach?: string[];
       }) => {
         if (opts.draftId) {
           if (opts.title || opts.content || opts.richText) {
@@ -472,6 +484,10 @@ export function registerSpaceCommand(program: Command): void {
           body.richText = parsed;
         }
         if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+        if (opts.attach && opts.attach.length > 0) {
+          assertPostAttachmentMix(opts.attach);
+          body.attachments = await uploadPostAttachments(opts.attach);
+        }
         const spaceSlug = resolveSpaceSlug(space, opts);
         const resp = (await apiPost(`/spaces/${spaceSlug}/posts`, body)) as Record<string, unknown>;
         const post = unwrapResp(resp) as Record<string, unknown>;

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import { WEBDRIVE_BASE_URL } from "../constants.js";
 import { getValidToken } from "../auth/manager.js";
 import { GobiError } from "../errors.js";
-import { apiGet } from "../client.js";
+import { apiDelete, apiGet, apiPatch, apiPost } from "../client.js";
 import { getVaultSlug, requireVault, runVaultInitFlow } from "./init.js";
 import { isJsonMode, jsonOut, unwrapResp } from "./utils.js";
 import { runSync, ConflictStrategy } from "./sync.js";
@@ -23,6 +23,86 @@ export function registerVaultCommand(program: Command): void {
     )
     .action(async () => {
       await runVaultInitFlow();
+    });
+
+  vault
+    .command("create <slug>")
+    .description(
+      "Create a new vault. <slug> must be unique (use 'gobi vault list' to see existing slugs); --name sets the display name. Does not change the configured vault — run 'gobi vault init' or 'gobi vault set-primary' afterwards if you want to anchor to it.",
+    )
+    .requiredOption("--name <name>", "Display name for the new vault")
+    .action(async (slug: string, opts: { name: string }) => {
+      const resp = (await apiPost("/vault", {
+        vaultId: slug,
+        name: opts.name,
+      })) as Record<string, unknown>;
+      const v = unwrapResp(resp) as Record<string, unknown>;
+
+      if (isJsonMode(vault)) {
+        jsonOut(v);
+        return;
+      }
+
+      console.log(`Created vault "${v.name}" [${v.vaultId}].`);
+    });
+
+  vault
+    .command("rename <newName>")
+    .description(
+      "Rename a vault. Defaults to the configured vault (.gobi/settings.yaml); pass --vault-slug to target another. Does not affect PUBLISH.md frontmatter (which controls the public profile title) — this is the local display name only.",
+    )
+    .option(
+      "--vault-slug <vaultSlug>",
+      "Vault slug to rename (defaults to .gobi/settings.yaml)",
+    )
+    .action(async (newName: string, opts: { vaultSlug?: string }) => {
+      const slug = opts.vaultSlug ?? getVaultSlug();
+      const resp = (await apiPatch(`/vault/${slug}`, {
+        name: newName,
+      })) as Record<string, unknown>;
+      const v = unwrapResp(resp) as Record<string, unknown>;
+
+      if (isJsonMode(vault)) {
+        jsonOut(v);
+        return;
+      }
+
+      console.log(`Renamed vault [${slug}] to "${v.name}".`);
+    });
+
+  vault
+    .command("delete <slug>")
+    .description(
+      "Delete a vault. Irreversible. Slug must be passed explicitly (no .gobi fallback). The API will reject if the vault still owns content; clean up posts, members, and files first.",
+    )
+    .action(async (slug: string) => {
+      await apiDelete(`/vault/${slug}`);
+
+      if (isJsonMode(vault)) {
+        jsonOut({ vaultSlug: slug });
+        return;
+      }
+
+      console.log(`Deleted vault [${slug}].`);
+    });
+
+  vault
+    .command("set-primary <slug>")
+    .description(
+      "Mark a vault as your primary. Unsets primary on the other vaults you own. Slug must be passed explicitly.",
+    )
+    .action(async (slug: string) => {
+      const resp = (await apiPatch(`/vault/${slug}`, {
+        isPrimary: true,
+      })) as Record<string, unknown>;
+      const v = unwrapResp(resp) as Record<string, unknown>;
+
+      if (isJsonMode(vault)) {
+        jsonOut(v);
+        return;
+      }
+
+      console.log(`Set [${slug}] as primary vault.`);
     });
 
   vault


### PR DESCRIPTION
## Summary
- The agent-driven `gobi <scope> create-reply --attach` contract from PR #565 (gobi-backend) was reverted (#566/#567/#568/#569 chain); `dispatchAgentMention` now detects every `gobi media generate-image` call in the turn, mirrors bytes from Miraflow → S3, and attaches them as `post_attachments` rows on the auto-posted reply.
- The SKILL.md still told the agent "call `gobi <scope> create-reply <postId> --attach <file>` yourself for media" — that's no longer the right path and produces dangling references.
- Rewrites the "Where you reference the downloaded file" section into three surfaces:
  - **Chat / vault note** — still `![[wikilink]]`.
  - **CLI-authored post or reply** (`gobi <scope> create-post / create-reply`) — still `--attach`.
  - **Post-mention auto-post** — **just write text**. Runtime auto-attaches every `generate-image` call from the turn. Embedding the image (wiki-link, markdown image, or URL) either dangles or duplicates the slider.
- "Key rules" bullet on `downloadUrl` expanded to call out "or nothing" as the third valid choice for the post-mention surface.

## Test plan
- [ ] Pull this branch + rebuild agent image; trigger a `@gobi 그림 그려줘` post-mention; verify the agent doesn't include any image link/wikilink in its reply body.
- [ ] CLI-authored `gobi space create-post --attach <file>` flow still works as documented (the `--attach` path stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)