### PR TITLE
Ship develop → main: v2.0.24 (edit-post --attach)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.23",
+      "version": "2.0.24",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.23</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.24</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Draft · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.23",
+      "version": "2.0.24",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.23).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.24).
 
 ## Prerequisites
 

--- a/skills/gobi-draft/SKILL.md
+++ b/skills/gobi-draft/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-draft
 
-Gobi draft commands for managing agent-authored drafts (v2.0.23).
+Gobi draft commands for managing agent-authored drafts (v2.0.24).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.23).
+Gobi media generation commands (v2.0.24).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.23).
+Gobi sense commands for activity and transcription data (v2.0.24).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.23).
+Gobi space, global, and personal-space posts (v2.0.24).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -100,6 +100,8 @@ Options:
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug).
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before editing (uses --vault-slug or .gobi vault)
+  --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
+                            ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/personal.md
+++ b/skills/gobi-space/references/personal.md
@@ -96,6 +96,8 @@ Options:
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug).
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before editing (uses --vault-slug or .gobi vault)
+  --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
+                            ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -143,6 +143,8 @@ Options:
   --auto-attachments        Upload wiki-linked [[files]] to webdrive before editing (also attributes the post to that vault)
   --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug). Also used as upload destination for --auto-attachments.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
+  --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
+                            ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.23"
+  version: "2.0.24"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.23).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.24).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -385,6 +385,12 @@ export function registerGlobalCommand(program: Command): void {
       "--auto-attachments",
       "Upload wiki-linked [[files]] to webdrive before editing (uses --vault-slug or .gobi vault)",
     )
+    .option(
+      "--attach <file>",
+      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
     .action(async (
       postId: string,
       opts: {
@@ -393,16 +399,19 @@ export function registerGlobalCommand(program: Command): void {
         richText?: string;
         vaultSlug?: string;
         autoAttachments?: boolean;
+        attach?: string[];
       },
     ) => {
       const wantsVaultChange = !!(opts.vaultSlug || opts.autoAttachments);
+      const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
       if (
         opts.title == null &&
         opts.content == null &&
         opts.richText == null &&
-        !wantsVaultChange
+        !wantsVaultChange &&
+        !wantsAttachChange
       ) {
-        throw new Error("Provide at least --title, --content, --rich-text, or --vault-slug to update.");
+        throw new Error("Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
@@ -432,6 +441,10 @@ export function registerGlobalCommand(program: Command): void {
         body.richText = parsed;
       }
       if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
+      if (opts.attach && opts.attach.length > 0) {
+        assertPostAttachmentMix(opts.attach);
+        body.attachments = await uploadPostAttachments(opts.attach);
+      }
       const resp = (await apiPatch(`/posts/${postId}`, body)) as Record<string, unknown>;
       const post = unwrapResp(resp) as Record<string, unknown>;
 

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -394,6 +394,12 @@ export function registerPersonalCommand(program: Command): void {
       "--auto-attachments",
       "Upload wiki-linked [[files]] to webdrive before editing (uses --vault-slug or .gobi vault)",
     )
+    .option(
+      "--attach <file>",
+      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
     .action(async (
       postId: string,
       opts: {
@@ -402,16 +408,19 @@ export function registerPersonalCommand(program: Command): void {
         richText?: string;
         vaultSlug?: string;
         autoAttachments?: boolean;
+        attach?: string[];
       },
     ) => {
       const wantsVaultChange = !!(opts.vaultSlug || opts.autoAttachments);
+      const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
       if (
         opts.title == null &&
         opts.content == null &&
         opts.richText == null &&
-        !wantsVaultChange
+        !wantsVaultChange &&
+        !wantsAttachChange
       ) {
-        throw new Error("Provide at least --title, --content, --rich-text, or --vault-slug to update.");
+        throw new Error("Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
@@ -441,6 +450,10 @@ export function registerPersonalCommand(program: Command): void {
         body.richText = parsed;
       }
       if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
+      if (opts.attach && opts.attach.length > 0) {
+        assertPostAttachmentMix(opts.attach);
+        body.attachments = await uploadPostAttachments(opts.attach);
+      }
       const resp = (await apiPatch(`/posts/${postId}`, body)) as Record<string, unknown>;
       const post = unwrapResp(resp) as Record<string, unknown>;
 

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -557,20 +557,28 @@ export function registerSpaceCommand(program: Command): void {
       "Attribute the post to this vault (sets authorVaultSlug). Also used as upload destination for --auto-attachments.",
     )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
+    .option(
+      "--attach <file>",
+      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
+    )
     .action(
       async (
         postId: string,
-        opts: { title?: string; content?: string; richText?: string; autoAttachments?: boolean; vaultSlug?: string; spaceSlug?: string },
+        opts: { title?: string; content?: string; richText?: string; autoAttachments?: boolean; vaultSlug?: string; spaceSlug?: string; attach?: string[] },
       ) => {
         const wantsVaultChange = !!(opts.vaultSlug || opts.autoAttachments);
+        const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
         if (
           opts.title == null &&
           opts.content == null &&
           opts.richText == null &&
-          !wantsVaultChange
+          !wantsVaultChange &&
+          !wantsAttachChange
         ) {
           throw new Error(
-            "Provide at least --title, --content, --rich-text, or --vault-slug to update.",
+            "Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.",
           );
         }
         if (opts.content && opts.richText) {
@@ -602,6 +610,10 @@ export function registerSpaceCommand(program: Command): void {
           body.richText = parsed;
         }
         if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
+        if (opts.attach && opts.attach.length > 0) {
+          assertPostAttachmentMix(opts.attach);
+          body.attachments = await uploadPostAttachments(opts.attach);
+        }
         const resp = (await apiPatch(
           `/spaces/${spaceSlug}/posts/${postId}`,
           body,


### PR DESCRIPTION
## Summary
- Adds `--attach <file>` (repeatable) to `edit-post` across personal, global, and space lanes — mirrors the create-post flag with the same X-style mix rules. Omitting it leaves attachments untouched; passing it replaces the attachment set wholesale.
- Bumps to v2.0.24; regenerates skill docs and the cheatsheet HTML.

## Test plan
- [ ] `gobi space edit-post <id> --attach foo.jpg` replaces attachments and the response reflects the new set
- [ ] `gobi global edit-post <id> --content "..."` without `--attach` leaves attachments unchanged
- [ ] `gobi personal edit-post <id> --title "..."` still works with no attachment ops

## Notes
- Requires matching backend changes to `EditPostDto` (shipped separately in gobi-backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)