### PR TITLE
Release v2.0.26: move vault-anchoring off post commands onto artifacts; regenerate cheatsheet + skill docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.25",
+      "version": "2.0.26",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/build.py
+++ b/docs/cheatsheet/build.py
@@ -217,7 +217,7 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
       <ul>
         <li><span><span class="cmd">space list</span> · <span class="cmd">space warp [slug]</span></span></li>
         <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--auto-attachments --vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
         <li><span><span class="cmd">space feed</span> · <span class="cmd">list-posts</span> · <span class="cmd">get-post &lt;id&gt;</span> <span class="flag">[--full]</span></span></li>
         <li><span><span class="cmd">space list-topics</span> · <span class="cmd">list-topic-posts &lt;slug&gt;</span></span></li>
       </ul>
@@ -240,7 +240,7 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
       <ul>
         <li><span><span class="cmd">global feed</span> <span class="flag">[--limit --cursor --following]</span> · <span class="cmd">personal feed</span></span></li>
         <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--auto-attachments --vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
         <li><span><span class="cmd">global list-posts</span> <span class="flag">[--mine --vault-slug]</span> · <span class="cmd">get-post</span> <span class="flag">[--full]</span> · <span class="cmd">edit-post / delete-post</span></span></li>
         <li><span><span class="desc"><code class="flag">personal</code> mirrors <code class="flag">global</code> with identical flags — private scope, visible only to you</span></span></li>
       </ul>
@@ -294,8 +294,8 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
   <footer class="footer">
     <div class="workflows">
       <div class="lbl">Common workflows</div>
-      <div class="row"><span class="key">Share</span>gobi space create-post --title "..." --content "..." --auto-attachments</div>
-      <div class="row"><span class="key">Public</span>gobi global create-post --title "..." --content "..." --auto-attachments</div>
+      <div class="row"><span class="key">Share</span>gobi space create-post --title "..." --content "..."</div>
+      <div class="row"><span class="key">Public</span>gobi global create-post --title "..." --content "..."</div>
       <div class="row"><span class="key">Sync</span>gobi vault sync --conflict client</div>
     </div>
     <div class="meta">

--- a/docs/cheatsheet/build.py
+++ b/docs/cheatsheet/build.py
@@ -216,8 +216,8 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
       <h2>Space <span class="sub">posts in a space</span></h2>
       <ul>
         <li><span><span class="cmd">space list</span> · <span class="cmd">space warp [slug]</span></span></li>
-        <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--artifact --attach --repost-post-id]</span></span></li>
+        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--attach]</span></span></li>
         <li><span><span class="cmd">space feed</span> · <span class="cmd">list-posts</span> · <span class="cmd">get-post &lt;id&gt;</span> <span class="flag">[--full]</span></span></li>
         <li><span><span class="cmd">space list-topics</span> · <span class="cmd">list-topic-posts &lt;slug&gt;</span></span></li>
       </ul>
@@ -239,8 +239,8 @@ HTML = f"""<!DOCTYPE html><html lang="en"><head>
       <h2>Global / Personal <span class="sub">public feed &amp; your private feed</span></h2>
       <ul>
         <li><span><span class="cmd">global feed</span> <span class="flag">[--limit --cursor --following]</span> · <span class="cmd">personal feed</span></span></li>
-        <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--artifact --attach --repost-post-id]</span></span></li>
+        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--attach]</span></span></li>
         <li><span><span class="cmd">global list-posts</span> <span class="flag">[--mine --vault-slug]</span> · <span class="cmd">get-post</span> <span class="flag">[--full]</span> · <span class="cmd">edit-post / delete-post</span></span></li>
         <li><span><span class="desc"><code class="flag">personal</code> mirrors <code class="flag">global</code> with identical flags — private scope, visible only to you</span></span></li>
       </ul>

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.25</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.26</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -197,7 +197,7 @@ body{
       <ul>
         <li><span><span class="cmd">space list</span> · <span class="cmd">space warp [slug]</span></span></li>
         <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--auto-attachments --vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
         <li><span><span class="cmd">space feed</span> · <span class="cmd">list-posts</span> · <span class="cmd">get-post &lt;id&gt;</span> <span class="flag">[--full]</span></span></li>
         <li><span><span class="cmd">space list-topics</span> · <span class="cmd">list-topic-posts &lt;slug&gt;</span></span></li>
       </ul>
@@ -220,7 +220,7 @@ body{
       <ul>
         <li><span><span class="cmd">global feed</span> <span class="flag">[--limit --cursor --following]</span> · <span class="cmd">personal feed</span></span></li>
         <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--auto-attachments --vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
         <li><span><span class="cmd">global list-posts</span> <span class="flag">[--mine --vault-slug]</span> · <span class="cmd">get-post</span> <span class="flag">[--full]</span> · <span class="cmd">edit-post / delete-post</span></span></li>
         <li><span><span class="desc"><code class="flag">personal</code> mirrors <code class="flag">global</code> with identical flags — private scope, visible only to you</span></span></li>
       </ul>
@@ -274,8 +274,8 @@ body{
   <footer class="footer">
     <div class="workflows">
       <div class="lbl">Common workflows</div>
-      <div class="row"><span class="key">Share</span>gobi space create-post --title "..." --content "..." --auto-attachments</div>
-      <div class="row"><span class="key">Public</span>gobi global create-post --title "..." --content "..." --auto-attachments</div>
+      <div class="row"><span class="key">Share</span>gobi space create-post --title "..." --content "..."</div>
+      <div class="row"><span class="key">Public</span>gobi global create-post --title "..." --content "..."</div>
       <div class="row"><span class="key">Sync</span>gobi vault sync --conflict client</div>
     </div>
     <div class="meta">

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -196,8 +196,8 @@ body{
       <h2>Space <span class="sub">posts in a space</span></h2>
       <ul>
         <li><span><span class="cmd">space list</span> · <span class="cmd">space warp [slug]</span></span></li>
-        <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">space create-post</span> <span class="flag">--title --content [--artifact --attach --repost-post-id]</span></span></li>
+        <li><span><span class="cmd">space create-reply &lt;id&gt;</span> <span class="flag">--content [--attach]</span></span></li>
         <li><span><span class="cmd">space feed</span> · <span class="cmd">list-posts</span> · <span class="cmd">get-post &lt;id&gt;</span> <span class="flag">[--full]</span></span></li>
         <li><span><span class="cmd">space list-topics</span> · <span class="cmd">list-topic-posts &lt;slug&gt;</span></span></li>
       </ul>
@@ -219,8 +219,8 @@ body{
       <h2>Global / Personal <span class="sub">public feed &amp; your private feed</span></h2>
       <ul>
         <li><span><span class="cmd">global feed</span> <span class="flag">[--limit --cursor --following]</span> · <span class="cmd">personal feed</span></span></li>
-        <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--vault-slug --attach --repost-post-id]</span></span></li>
-        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--vault-slug --attach]</span></span></li>
+        <li><span><span class="cmd">global create-post</span> <span class="flag">--title --content [--artifact --attach --repost-post-id]</span></span></li>
+        <li><span><span class="cmd">global create-reply &lt;id&gt;</span> <span class="flag">--content [--attach]</span></span></li>
         <li><span><span class="cmd">global list-posts</span> <span class="flag">[--mine --vault-slug]</span> · <span class="cmd">get-post</span> <span class="flag">[--full]</span> · <span class="cmd">edit-post / delete-post</span></span></li>
         <li><span><span class="desc"><code class="flag">personal</code> mirrors <code class="flag">global</code> with identical flags — private scope, visible only to you</span></span></li>
       </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.25",
+      "version": "2.0.26",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.25).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.26).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.25).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.26).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.25).
+Gobi media generation commands (v2.0.26).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.25).
+Gobi sense commands for activity and transcription data (v2.0.26).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.25).
+Gobi space, global, and personal-space posts (v2.0.26).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -12,8 +12,7 @@ Commands:
   feed [options]                   List the unified feed (posts and replies, newest first) in the global public feed.
   list-posts [options]             List posts in the global feed (paginated). Pass --mine to limit to your own posts.
   get-post [options] <postId>      Get a global post with its ancestors and replies (paginated).
-  create-post [options]            Create a post in the global feed. --vault-slug attributes it to a vault you own. With no --vault-slug, the post is created without an authorVaultSlug (vault-less
-                                   personal post).
+  create-post [options]            Create a post in the global feed.
   edit-post [options] <postId>     Edit a post you authored in the global feed.
   delete-post <postId>             Delete a post you authored in the global feed.
   create-reply [options] <postId>  Create a reply to a post in the global feed.
@@ -70,13 +69,13 @@ Options:
 ```
 Usage: gobi global create-post [options]
 
-Create a post in the global feed. --vault-slug attributes it to a vault you own. With no --vault-slug, the post is created without an authorVaultSlug (vault-less personal post).
+Create a post in the global feed.
 
 Options:
   --title <title>            Title of the post
   --content <content>        Post content (markdown supported, use "-" for stdin)
   --rich-text <richText>     Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>   Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.
+  --artifact <artifactId>    Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`. (default: [])
   --attach <file>            Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default: [])
   --repost-post-id <postId>  Wrap an existing top-level post as the embedded card on this new post. Composes with --content / --rich-text / --attach (the wrapping author's text + media render above
                              the embedded card). Reposts-of-reposts are collapsed to the transitive root server-side. The referenced post must exist, not be deleted, and not itself be a reply.
@@ -91,13 +90,12 @@ Usage: gobi global edit-post [options] <postId>
 Edit a post you authored in the global feed.
 
 Options:
-  --title <title>           New title
-  --content <content>       New content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug).
-  --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
-                            ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
-  -h, --help                display help for command
+  --title <title>         New title
+  --content <content>     New content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  --attach <file>         Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
+                          ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
+  -h, --help              display help for command
 ```
 
 ## delete-post
@@ -119,12 +117,11 @@ Usage: gobi global create-reply [options] <postId>
 Create a reply to a post in the global feed.
 
 Options:
-  --content <content>       Reply content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug).
-  --attach <file>           Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
-                            [])
-  -h, --help                display help for command
+  --content <content>     Reply content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  --attach <file>         Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
+                          [])
+  -h, --help              display help for command
 ```
 
 ## edit-reply
@@ -135,10 +132,9 @@ Usage: gobi global edit-reply [options] <replyId>
 Edit a reply you authored in the global feed.
 
 Options:
-  --content <content>       New reply content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug).
-  -h, --help                display help for command
+  --content <content>     New reply content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  -h, --help              display help for command
 ```
 
 ## delete-reply

--- a/skills/gobi-space/references/personal.md
+++ b/skills/gobi-space/references/personal.md
@@ -13,7 +13,7 @@ Commands:
   feed [options]                   List your personal-space feed (posts and replies, newest first). Only you can see these rows.
   list-posts [options]             List root posts (no replies) in your personal space. Filters the personal feed client-side; pagination cursor advances through the underlying feed page.
   get-post [options] <postId>      Get a personal-space post with its ancestors and replies (paginated). Same endpoint as `gobi global get-post`; only the owner can resolve a private id.
-  create-post [options]            Create a private post in your personal space. --vault-slug attributes it to a vault you own. Visible only to you.
+  create-post [options]            Create a private post in your personal space. Visible only to you.
   edit-post [options] <postId>     Edit a post you authored in your personal space.
   delete-post <postId>             Delete a post you authored in your personal space.
   create-reply [options] <postId>  Reply to a personal-space post. The reply inherits the parent's private scope automatically.
@@ -67,13 +67,13 @@ Options:
 ```
 Usage: gobi personal create-post [options]
 
-Create a private post in your personal space. --vault-slug attributes it to a vault you own. Visible only to you.
+Create a private post in your personal space. Visible only to you.
 
 Options:
   --title <title>            Title of the post
   --content <content>        Post content (markdown supported, use "-" for stdin)
   --rich-text <richText>     Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>   Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.
+  --artifact <artifactId>    Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`. (default: [])
   --attach <file>            Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default: [])
   --repost-post-id <postId>  Wrap an existing top-level post as the embedded card on this new private post. The referenced post must be visible to you (your own personal-space post, a global-feed
                              post, or a post in a space you're a member of). Reposting someone else's personal-space post returns 404.
@@ -88,13 +88,12 @@ Usage: gobi personal edit-post [options] <postId>
 Edit a post you authored in your personal space.
 
 Options:
-  --title <title>           New title
-  --content <content>       New content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug).
-  --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
-                            ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
-  -h, --help                display help for command
+  --title <title>         New title
+  --content <content>     New content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  --attach <file>         Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
+                          ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
+  -h, --help              display help for command
 ```
 
 ## delete-post
@@ -116,12 +115,11 @@ Usage: gobi personal create-reply [options] <postId>
 Reply to a personal-space post. The reply inherits the parent's private scope automatically.
 
 Options:
-  --content <content>       Reply content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug).
-  --attach <file>           Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
-                            [])
-  -h, --help                display help for command
+  --content <content>     Reply content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  --attach <file>         Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
+                          [])
+  -h, --help              display help for command
 ```
 
 ## edit-reply
@@ -132,10 +130,9 @@ Usage: gobi personal edit-reply [options] <replyId>
 Edit a reply you authored in your personal space.
 
 Options:
-  --content <content>       New reply content (markdown supported, use "-" for stdin)
-  --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug).
-  -h, --help                display help for command
+  --content <content>     New reply content (markdown supported, use "-" for stdin)
+  --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
+  -h, --help              display help for command
 ```
 
 ## delete-reply

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -118,7 +118,7 @@ Options:
   --title <title>            Title of the post
   --content <content>        Post content (markdown supported, use "-" for stdin)
   --rich-text <richText>     Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>   Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.
+  --artifact <artifactId>    Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`. (default: [])
   --space-slug <spaceSlug>   Space slug (overrides .gobi/settings.yaml)
   --attach <file>            Local media file to attach. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default: [])
   --repost-post-id <postId>  Wrap an existing top-level post as the embedded card on this new post. Composes with --content / --rich-text / --attach (the wrapping author's text + media render above
@@ -137,7 +137,6 @@ Options:
   --title <title>           New title for the post
   --content <content>       New content for the post (markdown supported, use "-" for stdin)
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
   --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size
                             ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged. (default: [])
@@ -166,7 +165,6 @@ Create a reply to a post in a space.
 Options:
   --content <content>       Reply content (markdown supported, use "-" for stdin)
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug). Caller must own the vault.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
   --attach <file>           Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. (default:
                             [])
@@ -183,7 +181,6 @@ Edit a reply you authored in a space.
 Options:
   --content <content>       New content for the reply (markdown supported, use "-" for stdin)
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
-  --vault-slug <vaultSlug>  Attribute the reply to this vault (sets authorVaultSlug). Caller must own the vault.
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
   -h, --help                display help for command
 ```

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.25"
+  version: "2.0.26"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.25).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.26).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -5,7 +5,6 @@ import {
   isJsonMode,
   jsonOut,
   readStdin,
-  resolveVaultSlug,
   unwrapResp,
 } from "./utils.js";
 import {
@@ -233,7 +232,7 @@ export function registerGlobalCommand(program: Command): void {
   global
     .command("create-post")
     .description(
-      "Create a post in the global feed. --vault-slug attributes it to a vault you own. With no --vault-slug, the post is created without an authorVaultSlug (vault-less personal post).",
+      "Create a post in the global feed.",
     )
     .option("--title <title>", "Title of the post")
     .option("--content <content>", "Post content (markdown supported, use \"-\" for stdin)")
@@ -242,8 +241,10 @@ export function registerGlobalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.",
+      "--artifact <artifactId>",
+      "Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
     )
     .option(
       "--attach <file>",
@@ -259,7 +260,7 @@ export function registerGlobalCommand(program: Command): void {
       title?: string;
       content?: string;
       richText?: string;
-      vaultSlug?: string;
+      artifact?: string[];
       attach?: string[];
       repostPostId?: string;
     }) => {
@@ -270,10 +271,6 @@ export function registerGlobalCommand(program: Command): void {
         throw new Error("--content and --rich-text are mutually exclusive.");
       }
 
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug({ vaultSlug: opts.vaultSlug });
-      }
       const body: Record<string, unknown> = {};
       if (opts.title != null) body.title = opts.title;
       if (opts.content != null) {
@@ -288,7 +285,7 @@ export function registerGlobalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+      if (opts.artifact && opts.artifact.length > 0) body.artifactIds = opts.artifact;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -331,10 +328,6 @@ export function registerGlobalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug).",
-    )
-    .option(
       "--attach <file>",
       "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged.",
       (value: string, prev: string[] = []) => [...prev, value],
@@ -346,27 +339,20 @@ export function registerGlobalCommand(program: Command): void {
         title?: string;
         content?: string;
         richText?: string;
-        vaultSlug?: string;
         attach?: string[];
       },
     ) => {
-      const wantsVaultChange = !!opts.vaultSlug;
       const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
       if (
         opts.title == null &&
         opts.content == null &&
         opts.richText == null &&
-        !wantsVaultChange &&
         !wantsAttachChange
       ) {
-        throw new Error("Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.");
+        throw new Error("Provide at least --title, --content, --rich-text, or --attach to update.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
-      }
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
       }
       const body: Record<string, unknown> = {};
       if (opts.title != null) body.title = opts.title;
@@ -382,7 +368,6 @@ export function registerGlobalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -427,25 +412,17 @@ export function registerGlobalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug).",
-    )
-    .option(
       "--attach <file>",
       "Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
-    .action(async (postId: string, opts: { content?: string; richText?: string; vaultSlug?: string; attach?: string[] }) => {
+    .action(async (postId: string, opts: { content?: string; richText?: string; attach?: string[] }) => {
       if (!opts.content && !opts.richText) {
         throw new Error("Provide either --content or --rich-text.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
-      }
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
       }
       const body: Record<string, unknown> = {};
       if (opts.content != null) {
@@ -460,7 +437,6 @@ export function registerGlobalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -492,27 +468,18 @@ export function registerGlobalCommand(program: Command): void {
       "--rich-text <richText>",
       "Rich-text JSON array (mutually exclusive with --content)",
     )
-    .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug).",
-    )
     .action(
       async (
         replyId: string,
-        opts: { content?: string; richText?: string; vaultSlug?: string },
+        opts: { content?: string; richText?: string },
       ) => {
-        const wantsVaultChange = !!opts.vaultSlug;
-        if (opts.content == null && opts.richText == null && !wantsVaultChange) {
+        if (opts.content == null && opts.richText == null) {
           throw new Error(
-            "Provide at least --content, --rich-text, or --vault-slug to update.",
+            "Provide at least --content or --rich-text to update.",
           );
         }
         if (opts.content && opts.richText) {
           throw new Error("--content and --rich-text are mutually exclusive.");
-        }
-        let authorVaultSlug: string | undefined;
-        if (opts.vaultSlug) {
-          authorVaultSlug = resolveVaultSlug(opts);
         }
         const body: Record<string, unknown> = {};
         if (opts.content != null) {
@@ -527,7 +494,6 @@ export function registerGlobalCommand(program: Command): void {
           }
           body.richText = parsed;
         }
-        if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
         const resp = (await apiPatch(`/posts/replies/${replyId}`, body)) as Record<string, unknown>;
         const reply = unwrapResp(resp) as Record<string, unknown>;
 

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -4,7 +4,6 @@ import {
   isJsonMode,
   jsonOut,
   readStdin,
-  resolveVaultSlug,
   unwrapResp,
 } from "./utils.js";
 import {
@@ -242,7 +241,7 @@ export function registerPersonalCommand(program: Command): void {
   personal
     .command("create-post")
     .description(
-      "Create a private post in your personal space. --vault-slug attributes it to a vault you own. Visible only to you.",
+      "Create a private post in your personal space. Visible only to you.",
     )
     .option("--title <title>", "Title of the post")
     .option("--content <content>", "Post content (markdown supported, use \"-\" for stdin)")
@@ -251,8 +250,10 @@ export function registerPersonalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.",
+      "--artifact <artifactId>",
+      "Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
     )
     .option(
       "--attach <file>",
@@ -268,7 +269,7 @@ export function registerPersonalCommand(program: Command): void {
       title?: string;
       content?: string;
       richText?: string;
-      vaultSlug?: string;
+      artifact?: string[];
       attach?: string[];
       repostPostId?: string;
     }) => {
@@ -279,10 +280,6 @@ export function registerPersonalCommand(program: Command): void {
         throw new Error("--content and --rich-text are mutually exclusive.");
       }
 
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug({ vaultSlug: opts.vaultSlug });
-      }
       const body: Record<string, unknown> = {};
       if (opts.title != null) body.title = opts.title;
       if (opts.content != null) {
@@ -297,7 +294,7 @@ export function registerPersonalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+      if (opts.artifact && opts.artifact.length > 0) body.artifactIds = opts.artifact;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -342,10 +339,6 @@ export function registerPersonalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug).",
-    )
-    .option(
       "--attach <file>",
       "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video. Omit to leave attachments unchanged.",
       (value: string, prev: string[] = []) => [...prev, value],
@@ -357,27 +350,20 @@ export function registerPersonalCommand(program: Command): void {
         title?: string;
         content?: string;
         richText?: string;
-        vaultSlug?: string;
         attach?: string[];
       },
     ) => {
-      const wantsVaultChange = !!opts.vaultSlug;
       const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
       if (
         opts.title == null &&
         opts.content == null &&
         opts.richText == null &&
-        !wantsVaultChange &&
         !wantsAttachChange
       ) {
-        throw new Error("Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.");
+        throw new Error("Provide at least --title, --content, --rich-text, or --attach to update.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
-      }
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
       }
       const body: Record<string, unknown> = {};
       if (opts.title != null) body.title = opts.title;
@@ -393,7 +379,6 @@ export function registerPersonalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -443,25 +428,17 @@ export function registerPersonalCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug).",
-    )
-    .option(
       "--attach <file>",
       "Local media file to attach to this reply. Repeatable. X-style mix rule: up to 4 photos OR 1 GIF OR 1 video. Size ceilings: 5MB photos / 15MB GIFs / 512MB video.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
-    .action(async (postId: string, opts: { content?: string; richText?: string; vaultSlug?: string; attach?: string[] }) => {
+    .action(async (postId: string, opts: { content?: string; richText?: string; attach?: string[] }) => {
       if (!opts.content && !opts.richText) {
         throw new Error("Provide either --content or --rich-text.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
-      }
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
       }
       const body: Record<string, unknown> = {};
       if (opts.content != null) {
@@ -476,7 +453,6 @@ export function registerPersonalCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -508,27 +484,18 @@ export function registerPersonalCommand(program: Command): void {
       "--rich-text <richText>",
       "Rich-text JSON array (mutually exclusive with --content)",
     )
-    .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug).",
-    )
     .action(
       async (
         replyId: string,
-        opts: { content?: string; richText?: string; vaultSlug?: string },
+        opts: { content?: string; richText?: string },
       ) => {
-        const wantsVaultChange = !!opts.vaultSlug;
-        if (opts.content == null && opts.richText == null && !wantsVaultChange) {
+        if (opts.content == null && opts.richText == null) {
           throw new Error(
-            "Provide at least --content, --rich-text, or --vault-slug to update.",
+            "Provide at least --content or --rich-text to update.",
           );
         }
         if (opts.content && opts.richText) {
           throw new Error("--content and --rich-text are mutually exclusive.");
-        }
-        let authorVaultSlug: string | undefined;
-        if (opts.vaultSlug) {
-          authorVaultSlug = resolveVaultSlug(opts);
         }
         const body: Record<string, unknown> = {};
         if (opts.content != null) {
@@ -543,7 +510,6 @@ export function registerPersonalCommand(program: Command): void {
           }
           body.richText = parsed;
         }
-        if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
         const resp = (await apiPatch(`/posts/replies/${replyId}`, body)) as Record<string, unknown>;
         const reply = unwrapResp(resp) as Record<string, unknown>;
 

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -12,7 +12,6 @@ import {
   jsonOut,
   readStdin,
   resolveSpaceSlug,
-  resolveVaultSlug,
   unwrapResp,
 } from "./utils.js";
 import {
@@ -407,8 +406,10 @@ export function registerSpaceCommand(program: Command): void {
       "Rich-text JSON array (mutually exclusive with --content)",
     )
     .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.",
+      "--artifact <artifactId>",
+      "Attach an existing artifact to the post (repeatable). Create artifacts with `gobi artifact create`.",
+      (value: string, prev: string[] = []) => [...prev, value],
+      [] as string[],
     )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
@@ -426,7 +427,7 @@ export function registerSpaceCommand(program: Command): void {
         title?: string;
         content?: string;
         richText?: string;
-        vaultSlug?: string;
+        artifact?: string[];
         spaceSlug?: string;
         attach?: string[];
         repostPostId?: string;
@@ -438,10 +439,6 @@ export function registerSpaceCommand(program: Command): void {
           throw new Error("--content and --rich-text are mutually exclusive.");
         }
 
-        let authorVaultSlug: string | undefined;
-        if (opts.vaultSlug) {
-          authorVaultSlug = resolveVaultSlug({ vaultSlug: opts.vaultSlug });
-        }
         const body: Record<string, unknown> = {};
         if (opts.title != null) body.title = opts.title;
         if (opts.content != null) {
@@ -456,7 +453,7 @@ export function registerSpaceCommand(program: Command): void {
           }
           body.richText = parsed;
         }
-        if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
+        if (opts.artifact && opts.artifact.length > 0) body.artifactIds = opts.artifact;
         if (opts.attach && opts.attach.length > 0) {
           assertPostAttachmentMix(opts.attach);
           body.attachments = await uploadPostAttachments(opts.attach);
@@ -501,10 +498,6 @@ export function registerSpaceCommand(program: Command): void {
       "--rich-text <richText>",
       "Rich-text JSON array (mutually exclusive with --content)",
     )
-    .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the post to this vault (sets authorVaultSlug). Caller must own the vault.",
-    )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--attach <file>",
@@ -515,29 +508,23 @@ export function registerSpaceCommand(program: Command): void {
     .action(
       async (
         postId: string,
-        opts: { title?: string; content?: string; richText?: string; vaultSlug?: string; spaceSlug?: string; attach?: string[] },
+        opts: { title?: string; content?: string; richText?: string; spaceSlug?: string; attach?: string[] },
       ) => {
-        const wantsVaultChange = !!opts.vaultSlug;
         const wantsAttachChange = !!(opts.attach && opts.attach.length > 0);
         if (
           opts.title == null &&
           opts.content == null &&
           opts.richText == null &&
-          !wantsVaultChange &&
           !wantsAttachChange
         ) {
           throw new Error(
-            "Provide at least --title, --content, --rich-text, --vault-slug, or --attach to update.",
+            "Provide at least --title, --content, --rich-text, or --attach to update.",
           );
         }
         if (opts.content && opts.richText) {
           throw new Error("--content and --rich-text are mutually exclusive.");
         }
         const spaceSlug = resolveSpaceSlug(space, opts);
-        let authorVaultSlug: string | undefined;
-        if (opts.vaultSlug) {
-          authorVaultSlug = resolveVaultSlug(opts);
-        }
         const body: Record<string, unknown> = {};
         if (opts.title != null) body.title = opts.title;
         if (opts.content != null) {
@@ -552,7 +539,6 @@ export function registerSpaceCommand(program: Command): void {
           }
           body.richText = parsed;
         }
-        if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
         if (opts.attach && opts.attach.length > 0) {
           assertPostAttachmentMix(opts.attach);
           body.attachments = await uploadPostAttachments(opts.attach);
@@ -606,10 +592,6 @@ export function registerSpaceCommand(program: Command): void {
       "--rich-text <richText>",
       "Rich-text JSON array (mutually exclusive with --content)",
     )
-    .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug). Caller must own the vault.",
-    )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--attach <file>",
@@ -617,16 +599,12 @@ export function registerSpaceCommand(program: Command): void {
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
-    .action(async (postId: string, opts: { content?: string; richText?: string; vaultSlug?: string; spaceSlug?: string; attach?: string[] }) => {
+    .action(async (postId: string, opts: { content?: string; richText?: string; spaceSlug?: string; attach?: string[] }) => {
       if (!opts.content && !opts.richText) {
         throw new Error("Provide either --content or --rich-text.");
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
-      }
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
       }
       const body: Record<string, unknown> = {};
       if (opts.content != null) {
@@ -641,7 +619,6 @@ export function registerSpaceCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug) body.authorVaultSlug = authorVaultSlug;
       if (opts.attach && opts.attach.length > 0) {
         assertPostAttachmentMix(opts.attach);
         body.attachments = await uploadPostAttachments(opts.attach);
@@ -675,26 +652,17 @@ export function registerSpaceCommand(program: Command): void {
       "--rich-text <richText>",
       "Rich-text JSON array (mutually exclusive with --content)",
     )
-    .option(
-      "--vault-slug <vaultSlug>",
-      "Attribute the reply to this vault (sets authorVaultSlug). Caller must own the vault.",
-    )
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
-    .action(async (replyId: string, opts: { content?: string; richText?: string; vaultSlug?: string; spaceSlug?: string }) => {
-      const wantsVaultChange = !!opts.vaultSlug;
-      if (opts.content == null && opts.richText == null && !wantsVaultChange) {
+    .action(async (replyId: string, opts: { content?: string; richText?: string; spaceSlug?: string }) => {
+      if (opts.content == null && opts.richText == null) {
         throw new Error(
-          "Provide at least --content, --rich-text, or --vault-slug to update.",
+          "Provide at least --content or --rich-text to update.",
         );
       }
       if (opts.content && opts.richText) {
         throw new Error("--content and --rich-text are mutually exclusive.");
       }
       const spaceSlug = resolveSpaceSlug(space, opts);
-      let authorVaultSlug: string | undefined;
-      if (opts.vaultSlug) {
-        authorVaultSlug = resolveVaultSlug(opts);
-      }
       const body: Record<string, unknown> = {};
       if (opts.content != null) {
         body.content = readContent(opts.content);
@@ -708,7 +676,6 @@ export function registerSpaceCommand(program: Command): void {
         }
         body.richText = parsed;
       }
-      if (authorVaultSlug !== undefined) body.authorVaultSlug = authorVaultSlug;
       const resp = (await apiPatch(
         `/spaces/${spaceSlug}/replies/${replyId}`,
         body,


### PR DESCRIPTION
## Summary
- **Release v2.0.26** (npm + GitHub Release + Homebrew already published from the `v2.0.26` tag; this PR brings the bump + features to `main` so the Claude Marketplace updates).
- **Vault-anchoring moved off post commands** (`cd42e1b`): removed `--vault-slug` from every post WRITE command (create-post / edit-post / create-reply / edit-reply across global / space / personal). Vault-anchored documents are now authored as artifacts (`gobi artifact create --kind markdown --vault-slug X`), which carry their own vault anchor for `[[wikilink]]` resolution. Added repeatable `--artifact <artifactId>` to create-post in all three scopes to attach an existing artifact. Read-only `list-posts --vault-slug` filter left intact.
- **Cheatsheet + skill docs**: Draft card/tag replaced with Artifact; stale `--auto-attachments` removed from create-reply entries; `skills/gobi-space/references/{global,personal,space}.md` regenerated to match the new flag surface.

## Test plan
- [x] `npm test` green in the release workflow (60/60), `tsc` clean
- [x] npm `@gobi-ai/cli@2.0.26` published, GitHub Release `v2.0.26` created, Homebrew formula updated
- [ ] After merge: confirm Claude Marketplace picks up v2.0.26 from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)