### PR TITLE
Release v2.0.27: complete vault-anchoring removal on post read paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "author": {
     "name": "gobi-ai"
   },

--- a/README.md
+++ b/README.md
@@ -178,30 +178,28 @@ A *Space* is a community knowledge area. A *Space Post* lives in one space. The 
 | `gobi space list-topic-posts <topicSlug>` | List posts tagged with a topic |
 | `gobi space list-posts` | List posts in the space |
 | `gobi space get-post <postId> [--full]` | Get a post with its ancestors and replies. `--full` shows reply content without truncation. |
-| `gobi space create-post [--title <t>] (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--repost-post-id <id>] [--attach <file>]…` | Create a space post. Must provide content via `--content` or `--rich-text`. `--vault-slug` attributes it to a vault you own. `--repost-post-id` reposts an existing post (sets `repostPostId` on the new post). `--attach` uploads local media to render inline in-feed (repeatable; X-style mix rule — up to 4 photos OR 1 GIF OR 1 video). |
-| `gobi space edit-post <postId> [--title <t>] [--content <c>] [--vault-slug <slug>]` | Edit a space post. `--vault-slug ""` detaches the vault. |
+| `gobi space create-post [--title <t>] (--content <c> \| --rich-text <json>) [--artifact <artifactId>]… [--repost-post-id <id>] [--attach <file>]…` | Create a space post. Must provide content via `--content` or `--rich-text`. `--artifact` attaches an existing artifact to the post (repeatable). `--repost-post-id` reposts an existing post (sets `repostPostId` on the new post). `--attach` uploads local media to render inline in-feed (repeatable; X-style mix rule — up to 4 photos OR 1 GIF OR 1 video). |
+| `gobi space edit-post <postId> [--title <t>] [--content <c>]` | Edit a space post. |
 | `gobi space delete-post <postId>` | Delete a space post |
-| `gobi space create-reply <postId> (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--attach <file>]…` | Create a reply to a space post. `--attach` works the same as on `create-post`. |
-| `gobi space edit-reply <replyId> [--content <c>] [--rich-text <json>] [--vault-slug <slug>]` | Edit a reply you authored. `--vault-slug ""` detaches attribution. |
+| `gobi space create-reply <postId> (--content <c> \| --rich-text <json>) [--attach <file>]…` | Create a reply to a space post. `--attach` works the same as on `create-post`. |
+| `gobi space edit-reply <replyId> [--content <c>] [--rich-text <json>]` | Edit a reply you authored. |
 | `gobi space delete-reply <replyId>` | Delete a reply you authored |
 
 ### Global feed (personal posts)
 
-A *Personal Post* surfaces in the public global feed. Pass `--vault-slug` to attribute it to a vault you own (it'll then surface on that vault's profile too); with no `--vault-slug` the post has no `authorVaultSlug` and lives only on the global feed. Same `Post` model as a Space Post, scoped to the user instead of a space.
+A *Personal Post* surfaces in the public global feed. Same `Post` model as a Space Post, scoped to the user instead of a space.
 
 | Command | Description |
 |---------|-------------|
 | `gobi global feed [--following]` | List the global public feed (posts + replies, newest first). `--following` limits to authors you follow. |
-| `gobi global list-posts [--mine] [--vault-slug <slug>]` | List personal posts; filter to your own or by author vault |
+| `gobi global list-posts [--mine]` | List personal posts; filter to your own |
 | `gobi global get-post <postId> [--full]` | Get a personal post with its ancestors and replies. `--full` shows reply content without truncation. |
-| `gobi global create-post [--title <t>] (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--repost-post-id <id>] [--attach <file>]…` | Create a personal post. `--repost-post-id` reposts an existing post. `--attach` uploads local media for inline rendering (see `gobi space create-post` above for the mix rule). |
-| `gobi global edit-post <postId> [--title <t>] [--content <c>] [--vault-slug <slug>]` | Edit a personal post you authored. `--vault-slug ""` detaches the vault. |
+| `gobi global create-post [--title <t>] (--content <c> \| --rich-text <json>) [--artifact <artifactId>]… [--repost-post-id <id>] [--attach <file>]…` | Create a personal post. `--artifact` attaches an existing artifact to the post (repeatable). `--repost-post-id` reposts an existing post. `--attach` uploads local media for inline rendering (see `gobi space create-post` above for the mix rule). |
+| `gobi global edit-post <postId> [--title <t>] [--content <c>]` | Edit a personal post you authored. |
 | `gobi global delete-post <postId>` | Delete a personal post you authored |
-| `gobi global create-reply <postId> (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--attach <file>]…` | Create a reply to a personal post |
-| `gobi global edit-reply <replyId> [--content <c>] [--rich-text <json>] [--vault-slug <slug>]` | Edit a reply you authored. `--vault-slug ""` detaches attribution. |
+| `gobi global create-reply <postId> (--content <c> \| --rich-text <json>) [--attach <file>]…` | Create a reply to a personal post |
+| `gobi global edit-reply <replyId> [--content <c>] [--rich-text <json>]` | Edit a reply you authored. |
 | `gobi global delete-reply <replyId>` | Delete a reply you authored |
-
-`--vault-slug` requires that the caller hold `role: 'owner'` on the target vault. When set, it becomes the post's `authorVaultSlug`.
 
 ### Personal space (private posts)
 
@@ -214,11 +212,11 @@ Private posts and replies visible only to you. Same `Post` data model and subcom
 | `gobi personal feed` | Your personal-space feed (posts + replies, newest first) |
 | `gobi personal list-posts` | List personal-space posts |
 | `gobi personal get-post <postId> [--full]` | Get a personal-space post with its ancestors and replies |
-| `gobi personal create-post [--title <t>] (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--repost-post-id <id>] [--attach <file>]…` | Create a private post in your personal space. `--vault-slug` attributes it to a vault you own. `--attach` works the same as on `gobi global create-post`. |
-| `gobi personal edit-post <postId> [--title <t>] [--content <c>] [--vault-slug <slug>]` | Edit a personal-space post you authored |
+| `gobi personal create-post [--title <t>] (--content <c> \| --rich-text <json>) [--artifact <artifactId>]… [--repost-post-id <id>] [--attach <file>]…` | Create a private post in your personal space. `--artifact` attaches an existing artifact to the post (repeatable). `--attach` works the same as on `gobi global create-post`. |
+| `gobi personal edit-post <postId> [--title <t>] [--content <c>]` | Edit a personal-space post you authored |
 | `gobi personal delete-post <postId>` | Delete a personal-space post you authored |
-| `gobi personal create-reply <postId> (--content <c> \| --rich-text <json>) [--vault-slug <slug>] [--attach <file>]…` | Reply to a personal-space post (inherits the parent's private scope) |
-| `gobi personal edit-reply <replyId> [--content <c>] [--rich-text <json>] [--vault-slug <slug>]` | Edit a reply you authored |
+| `gobi personal create-reply <postId> (--content <c> \| --rich-text <json>) [--attach <file>]…` | Reply to a personal-space post (inherits the parent's private scope) |
+| `gobi personal edit-reply <replyId> [--content <c>] [--rich-text <json>]` | Edit a reply you authored |
 | `gobi personal delete-reply <replyId>` | Delete a reply you authored |
 
 ### Sense

--- a/commands/space-share.md
+++ b/commands/space-share.md
@@ -14,7 +14,7 @@ First, verify the user is set up:
 gobi --json auth status
 ```
 
-Check that `.gobi/settings.yaml` exists. If you plan to publish to a Space (`gobi space create-post`), it must contain `selectedSpaceSlug` — otherwise stop and ask the user to run `gobi space warp` first. `vaultSlug` is optional for `gobi global create-post`; if missing the post is created without an `authorVaultSlug` (vault-less). Run `gobi vault init` if the user wants the post attributed to a vault they own.
+Check that `.gobi/settings.yaml` exists. If you plan to publish to a Space (`gobi space create-post`), it must contain `selectedSpaceSlug` — otherwise stop and ask the user to run `gobi space warp` first.
 
 ## Draft a personal post
 

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.26</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.27</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.26).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.27).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.26).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.27).
 
 ## Prerequisites
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -77,16 +77,8 @@ gobi auth status
 | `vault init` | no (it sets it up) | no | – |
 | `space list` / `warp [slug]` / `get [slug]` | no | no | – |
 | `space list-topics` / `feed` / `list-posts` / `get-post` / `create-post` / `edit-post` / `delete-post` / `create-reply` / `edit-reply` / `delete-reply` / `list-topic-posts` | no | **yes** | parent `--space-slug <slug>` |
-| `global feed` / `list-posts` / `get-post` / `delete-post` / `create-reply` / `edit-reply` / `delete-reply` | no | no | – |
-| `global create-post` | optional¹ | no | command-level `--vault-slug <slug>` |
-| `global edit-post` | optional² | no | command-level `--vault-slug <slug>` |
-| `personal feed` / `list-posts` / `get-post` / `delete-post` / `create-reply` / `edit-reply` / `delete-reply` | no | no | – |
-| `personal create-post` | optional¹ | no | command-level `--vault-slug <slug>` |
-| `personal edit-post` | optional² | no | command-level `--vault-slug <slug>` |
-
-¹ `global create-post` accepts `--vault-slug`, optional. With no flag and no `vaultSlug` in `.gobi`, the post is created with no `authorVaultSlug` (vault-less personal post) — same as a Space post that isn't attributed to any vault. Set `--vault-slug` to attribute it.
-
-² `global edit-post` only consults `--vault-slug` when you pass it explicitly. Use `--vault-slug ""` to detach an existing attribution; non-empty re-attaches.
+| `global feed` / `list-posts` / `get-post` / `create-post` / `edit-post` / `delete-post` / `create-reply` / `edit-reply` / `delete-reply` | no | no | – |
+| `personal feed` / `list-posts` / `get-post` / `create-post` / `edit-post` / `delete-post` / `create-reply` / `edit-reply` / `delete-reply` | no | no | – |
 
 When a command needs vault or space and neither `.gobi` nor an override flag provides it, the CLI prints a one-line warning before the command runs (e.g. `Vault not set. Run 'gobi vault init' first, or pass --vault-slug.`). The warning is suppressed under `--json`.
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.26).
+Gobi media generation commands (v2.0.27).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.26).
+Gobi sense commands for activity and transcription data (v2.0.27).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.26).
+Gobi space, global, and personal-space posts (v2.0.27).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -25,10 +25,10 @@ Requires gobi-cli installed and authenticated. See the **gobi-core** skill for s
 The same `Post` data type drives all three surfaces — the difference is **scope**:
 
 - **Space Post** — `gobi space …` — lives in a community space's feed.
-- **Personal Post** — `gobi global …` — surfaces in the public global feed. When attributed via `--vault-slug` it also surfaces on that vault's profile; with no vault attribution it lives only on the global feed.
+- **Personal Post** — `gobi global …` — lives on the public global feed.
 - **Personal-space Post** — `gobi personal …` — private posts and replies visible only to the author. Same shape as `gobi global`, scoped via `personalSpaceUserId` so they never surface on the public feed.
 
-Anything you can do to a Space Post (reply, edit, delete, attribute to a vault) you can do to a Personal Post or a Personal-space Post.
+Anything you can do to a Space Post (reply, edit, delete) you can do to a Personal Post or a Personal-space Post.
 
 - When the user wants to explore or catch up on what's happening in their space, invoke `/gobi:space-explore`.
 - When the user wants to share or post learnings from the current session, invoke `/gobi:space-share`.
@@ -45,9 +45,9 @@ Anything you can do to a Space Post (reply, edit, delete, attribute to a vault) 
 
 The same applies to replies: a reply has only `--content` (no title), so do not synthesize a title-like heading at the top of a reply either.
 
-## Author vault attribution (`--vault-slug`)
+## Attaching artifacts (`--artifact`)
 
-`create-post` / `edit-post` across all three scopes (`gobi space`, `gobi global`, `gobi personal`) accept `--vault-slug <slug>`. When set, the slug becomes the post's `authorVaultSlug` — the vault the user is posting on behalf of. The caller must hold `role: 'owner'` on that vault. Pass `--vault-slug ""` on edit to detach.
+Posts have no vault attribution. `create-post` across all three scopes (`gobi space`, `gobi global`, `gobi personal`) accepts `--artifact <artifactId>` (repeatable) to attach existing artifacts to the post. To author a vault-anchored document, create a markdown artifact (`gobi artifact create --kind markdown --vault-slug <slug>`) and attach it via `--artifact`. See the **gobi-artifact** skill.
 
 > **Wiki-link uploads moved to artifacts.** The `--auto-attachments` flag that used to upload `[[wiki-linked files]]` from a post body now lives on `gobi artifact create` / `gobi artifact revise` (markdown kinds). To publish a markdown creation with resolvable wikilinks, create a markdown artifact with `--vault-slug` + `--auto-attachments` and attach it to the post (`--post-id`). See the **gobi-artifact** skill. Before relying on wikilink resolution, confirm the anchor vault is published: `gobi --json vault status --vault-slug <slug>` should report `isPublished: true`.
 
@@ -63,13 +63,12 @@ Use `--attach` for media you want shown in the post itself; use a markdown **art
 
 Once a post is created, you can build a shareable URL from the response:
 
-- **Personal post on a vault** — `https://gobispace.com/@{authorVaultSlug}?postId={id}` (e.g. `https://gobispace.com/@jyk?postId=144869`). This is the canonical share link for `gobi global` posts attributed to a vault.
-- **Personal post without a vault** (created with no `--vault-slug`) — use `https://gobispace.com/posts/{id}` as a direct fallback.
+- **Personal post** — `https://gobispace.com/posts/{id}` (e.g. `https://gobispace.com/posts/144869`). This is the canonical share link for `gobi global` posts.
 - **Space post** — `https://gobispace.com/spaces/{spaceSlug}?postId={id}` (overlay on the space feed) or `https://gobispace.com/spaces/{spaceSlug}/posts/{id}` (dedicated page).
 - **Vault profile** — `https://gobispace.com/@{vaultSlug}`.
 - **Vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). First-class URL for linking to a single file from a published vault — renders in the main feed chrome (not the vault homepage). Use this when a post body or reply needs to point readers at a specific vault file. URL-encode each path segment. See **gobi-vault** skill for full semantics.
 
-When you echo a "Post created!" line (or the JSON response is consumed by another agent), include the assembled URL using the fields actually returned (`id`, `authorVaultSlug`, `spaceSlug`) — don't fabricate slugs.
+When you echo a "Post created!" line (or the JSON response is consumed by another agent), include the assembled URL using the fields actually returned — `id` for global posts, `spaceSlug` + `id` for space posts. Don't fabricate slugs.
 
 ## Prerequisites & space slug
 
@@ -84,7 +83,7 @@ When you echo a "Post created!" line (or the JSON response is consumed by anothe
 
 If `.gobi/settings.yaml` has no `selectedSpaceSlug` and `--space-slug` isn't passed, the command will error.
 
-`gobi global` commands target the public global feed and have no space requirement and no `.gobi` requirement. `gobi global create-post` is symmetric with `gobi space create-post`: a vault is **optional** — pass `--vault-slug <slug>` to attribute the post; with no flag the post is created without an `authorVaultSlug`.
+`gobi global` commands target the public global feed and have no space requirement and no `.gobi` requirement. `gobi global create-post` is symmetric with `gobi space create-post`: attach existing artifacts with `--artifact <artifactId>` (repeatable).
 
 ## Important: JSON Mode
 
@@ -112,8 +111,8 @@ gobi --json space list-posts
 ### Space posts
 - `gobi space list-posts` — List posts in a space (paginated).
 - `gobi space get-post <postId>` — Get a post with its ancestors and replies (paginated). Ancestors and replies are returned together; there is no separate `ancestors` or `list-replies` command.
-- `gobi space create-post` — Create a space post. `--vault-slug` attributes it to a vault you own.
-- `gobi space edit-post <postId>` — Edit a space post. You must be the author. `--vault-slug ""` detaches the vault.
+- `gobi space create-post` — Create a space post. `--artifact <artifactId>` (repeatable) attaches existing artifacts.
+- `gobi space edit-post <postId>` — Edit a space post. You must be the author.
 - `gobi space delete-post <postId>` — Delete a space post. You must be the author.
 
 ### Space replies
@@ -126,25 +125,25 @@ gobi --json space list-posts
 `gobi global` is the same surface for Personal Posts — posts that live on the author's profile and surface in the public global feed.
 
 - `gobi global feed` — List the public global feed (posts and replies, newest first).
-- `gobi global list-posts` — List personal posts. `--mine` for your own; `--vault-slug <slug>` to filter by author vault.
+- `gobi global list-posts` — List personal posts. `--mine` for your own.
 - `gobi global get-post <postId>` — Get a personal post with its ancestors and replies.
-- `gobi global create-post` — Create a personal post. `--vault-slug` works the same as on `space create-post`. It is optional: with no flag, the post is created without an `authorVaultSlug` (vault-less personal post).
-- `gobi global edit-post <postId>` — Edit a personal post you authored. `--vault-slug ""` detaches the vault.
+- `gobi global create-post` — Create a personal post. `--artifact <artifactId>` (repeatable) attaches existing artifacts.
+- `gobi global edit-post <postId>` — Edit a personal post you authored.
 - `gobi global delete-post <postId>` — Delete a personal post you authored.
 - `gobi global create-reply <postId>` — Reply to a personal post.
-- `gobi global edit-reply <replyId>` — Edit a reply you authored. Accepts `--vault-slug` for author attribution (mirrors `space edit-reply`).
+- `gobi global edit-reply <replyId>` — Edit a reply you authored.
 - `gobi global delete-reply <replyId>` — Delete a reply you authored.
 
 ### Personal-space posts (private)
 
 `gobi personal` mirrors `gobi global`'s subcommand and write-flag shape, but every row is scoped to a private personal space (`personalSpaceUserId`). Nothing here surfaces on the public global feed — these posts are visible only to you. Use for private notes-as-posts, scratch drafts, or any post you want to author against your vault without making it public.
 
-A couple of read-side flags don't mirror — `personal feed` has no `--following` (there's no follow graph in a private space), and `personal list-posts` has no `--mine` / `--vault-slug` (everything in the personal space is already yours).
+A couple of read-side flags don't mirror — `personal feed` has no `--following` (there's no follow graph in a private space), and `personal list-posts` has no `--mine` (everything in the personal space is already yours).
 
 - `gobi personal feed` — Your personal-space feed (posts and replies, newest first).
 - `gobi personal list-posts` — List your personal-space posts.
 - `gobi personal get-post <postId>` — Get a personal-space post with its ancestors and replies.
-- `gobi personal create-post` — Create a private personal-space post. Same flags as `gobi global create-post` (`--vault-slug`, `--repost-post-id`, `--attach`).
+- `gobi personal create-post` — Create a private personal-space post. Same flags as `gobi global create-post` (`--artifact`, `--repost-post-id`, `--attach`).
 - `gobi personal edit-post <postId>` — Edit a personal-space post you authored.
 - `gobi personal delete-post <postId>` — Delete a personal-space post you authored.
 - `gobi personal create-reply <postId>` — Reply to a personal-space post (inherits the parent's private scope).
@@ -153,7 +152,7 @@ A couple of read-side flags don't mirror — `personal feed` has no `--following
 
 ## Confirm before mutating
 
-Most posts and replies are publicly visible — in a community space (`gobi space …`) or in the global feed (`gobi global …`). `gobi personal …` is the exception: those rows are private to the author. Either way, before running any write, confirm with the user — show the exact command and the resolved title, content (or a short preview), and `authorVaultSlug` if `--vault-slug` is set. This applies even when running autonomously.
+Most posts and replies are publicly visible — in a community space (`gobi space …`) or in the global feed (`gobi global …`). `gobi personal …` is the exception: those rows are private to the author. Either way, before running any write, confirm with the user — show the exact command and the resolved title, content (or a short preview), and any attached artifact ids. This applies even when running autonomously.
 
 - `create-post` / `create-reply` — content goes live on submission.
 - `edit-post` / `edit-reply` — confirm the *new* content; people who already saw the original may re-see it.

--- a/skills/gobi-space/references/global.md
+++ b/skills/gobi-space/references/global.md
@@ -43,11 +43,10 @@ Usage: gobi global list-posts [options]
 List posts in the global feed (paginated). Pass --mine to limit to your own posts.
 
 Options:
-  --limit <number>          Items per page (default: "20")
-  --cursor <string>         Pagination cursor from previous response
-  --mine                    Only include posts authored by you
-  --vault-slug <vaultSlug>  Filter by author vault slug
-  -h, --help                display help for command
+  --limit <number>   Items per page (default: "20")
+  --cursor <string>  Pagination cursor from previous response
+  --mine             Only include posts authored by you
+  -h, --help         display help for command
 ```
 
 ## get-post

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -56,11 +56,10 @@ gobi --json vault publish
 Once a vault is published (i.e. `gobi vault status` reports `isPublished: yes`), it is reachable at predictable URLs:
 
 - **Vault profile** — `https://gobispace.com/@{vaultSlug}` (e.g. `https://gobispace.com/@jyk`).
-- **Direct link to a personal post on the vault** — `https://gobispace.com/@{vaultSlug}?postId={postId}` (e.g. `https://gobispace.com/@jyk?postId=144869`). Open in the vault profile with that post focused.
 - **Direct link to a vault file** — `https://gobispace.com/file/{vaultSlug}?path={path}` (e.g. `https://gobispace.com/file/jyk?path=notes/intro.md`). This is the first-class URL for sharing a single file from a vault — use it whenever you want a reader to land on one specific file. The page renders inside the main feed chrome (sidebar + header), so readers stay in `gobispace.com` instead of pivoting to the vault homepage. Paths without an extension are treated as markdown (the same wikilink-stem resolution webdrive uses), so `?path=intro` and `?path=intro.md` both resolve. URL-encode each path segment when assembling.
 - **Custom homepage** — when `homepage` is set in `PUBLISH.md` frontmatter, the vault profile URL renders that HTML file. See **gobi-homepage** skill.
 
-When linking back to your own posts or files, assemble the URL from concrete fields (the post's `authorVaultSlug` + `id`, or the vault's `vaultSlug` + the file's path) rather than guessing.
+When linking to a vault file, assemble the URL from concrete fields (the vault's `vaultSlug` + the file's path) rather than guessing.
 
 ## Confirm before mutating
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.26"
+  version: "2.0.27"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.26).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.27).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -18,15 +18,7 @@ function readContent(value: string): string {
 }
 
 function buildPersonalPostUrl(post: Record<string, unknown>): string {
-  const id = post.id;
-  const vaultSlug =
-    ((post.vault as Record<string, unknown>)?.vaultSlug as string) ||
-    ((post.authorVault as Record<string, unknown>)?.vaultSlug as string) ||
-    (post.authorVaultSlug as string) ||
-    undefined;
-  return vaultSlug
-    ? `${WEB_BASE_URL}/@${vaultSlug}?postId=${id}`
-    : `${WEB_BASE_URL}/posts/${id}`;
+  return `${WEB_BASE_URL}/posts/${post.id}`;
 }
 
 function formatFeedLine(m: Record<string, unknown>): string {
@@ -99,14 +91,12 @@ export function registerGlobalCommand(program: Command): void {
     .option("--limit <number>", "Items per page", "20")
     .option("--cursor <string>", "Pagination cursor from previous response")
     .option("--mine", "Only include posts authored by you")
-    .option("--vault-slug <vaultSlug>", "Filter by author vault slug")
-    .action(async (opts: { limit: string; cursor?: string; mine?: boolean; vaultSlug?: string }) => {
+    .action(async (opts: { limit: string; cursor?: string; mine?: boolean }) => {
       const params: Record<string, unknown> = {
         limit: parseInt(opts.limit, 10),
       };
       if (opts.cursor) params.cursor = opts.cursor;
       if (opts.mine) params.mine = "true";
-      if (opts.vaultSlug) params.vaultSlug = opts.vaultSlug;
       const resp = (await apiGet(`/posts`, params)) as Record<string, unknown>;
 
       if (isJsonMode(global)) {
@@ -128,12 +118,8 @@ export function registerGlobalCommand(program: Command): void {
         const author =
           ((t.author as Record<string, unknown>)?.name as string) ||
           `User ${t.authorId}`;
-        const vaultSlug =
-          ((t.vault as Record<string, unknown>)?.vaultSlug as string) ||
-          ((t.authorVault as Record<string, unknown>)?.vaultSlug as string) ||
-          "?";
         lines.push(
-          `- [${t.id}] "${t.title}" by ${author} (vault: ${vaultSlug}, ${t.replyCount ?? 0} replies, ${t.createdAt})`,
+          `- [${t.id}] "${t.title}" by ${author} (${t.replyCount ?? 0} replies, ${t.createdAt})`,
         );
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
@@ -180,10 +166,6 @@ export function registerGlobalCommand(program: Command): void {
         const author =
           ((post.author as Record<string, unknown>)?.name as string) ||
           `User ${post.authorId}`;
-        const vault =
-          ((post.vault as Record<string, unknown>)?.vaultSlug as string) ||
-          ((post.authorVault as Record<string, unknown>)?.vaultSlug as string) ||
-          "?";
 
         const ancestorLines: string[] = [];
         if (ancestors.length) {
@@ -210,7 +192,7 @@ export function registerGlobalCommand(program: Command): void {
 
         const output = [
           heading,
-          `By: ${author} (vault: ${vault}) on ${post.createdAt}`,
+          `By: ${author} on ${post.createdAt}`,
           ...(ancestorLines.length
             ? ["", `Ancestors (${ancestors.length} items, root first):`, ...ancestorLines]
             : []),

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -122,12 +122,8 @@ export function registerPersonalCommand(program: Command): void {
       }
       const lines: string[] = [];
       for (const t of items) {
-        const vaultSlug =
-          ((t.vault as Record<string, unknown>)?.vaultSlug as string) ||
-          ((t.authorVault as Record<string, unknown>)?.vaultSlug as string) ||
-          "—";
         lines.push(
-          `- [${t.id}] "${t.title ?? "(no title)"}" (vault: ${vaultSlug}, ${t.replyCount ?? 0} replies, ${t.createdAt})`,
+          `- [${t.id}] "${t.title ?? "(no title)"}" (${t.replyCount ?? 0} replies, ${t.createdAt})`,
         );
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
@@ -183,10 +179,6 @@ export function registerPersonalCommand(program: Command): void {
         const author =
           ((post.author as Record<string, unknown>)?.name as string) ||
           `User ${post.authorId}`;
-        const vault =
-          ((post.vault as Record<string, unknown>)?.vaultSlug as string) ||
-          ((post.authorVault as Record<string, unknown>)?.vaultSlug as string) ||
-          "—";
 
         const ancestorLines: string[] = [];
         if (ancestors.length) {
@@ -213,7 +205,7 @@ export function registerPersonalCommand(program: Command): void {
 
         const output = [
           heading,
-          `By: ${author} (vault: ${vault}) on ${post.createdAt}`,
+          `By: ${author} on ${post.createdAt}`,
           ...(ancestorLines.length
             ? ["", `Ancestors (${ancestors.length} items, root first):`, ...ancestorLines]
             : []),


### PR DESCRIPTION
## Summary
- **Release v2.0.27** (npm + GitHub Release + Homebrew already published from the `v2.0.27` tag; this PR brings the bump + feature to `main` so the Claude Marketplace updates).
- **Completes the vault-anchoring removal on read paths** (`1c4fc70`, follows `cd42e1b` which handled the write commands):
  - `global list-posts`: dropped the `--vault-slug` filter option.
  - list-posts + get-post human-readable output (global + personal): removed the `vault: <slug>` attribution line.
  - `buildPersonalPostUrl`: always returns `${WEB_BASE_URL}/posts/<id>` — no vault-slug profile URL.
  - README, `commands/space-share.md`, and skill docs (gobi-core, gobi-space, gobi-vault + global reference) updated to drop `--vault-slug` and document `--artifact`.

## Test plan
- [x] `tsc` clean, 60/60 tests pass (release workflow + local)
- [x] npm `@gobi-ai/cli@2.0.27` published, GitHub Release `v2.0.27` created, Homebrew formula updated
- [ ] After merge: confirm Claude Marketplace picks up v2.0.27 from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)