### PR TITLE
homepage/vault/sync: robust custom-homepage publish flow (v2.0.30)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.29",
+      "version": "2.0.30",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "author": {
     "name": "gobi-ai"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.29",
+      "version": "2.0.30",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.29).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.30).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.29).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.30).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -20,13 +20,26 @@ A **Gobi Homepage** is a custom HTML page hosted on a vault's webdrive and serve
 
 ## Setup
 
-1. Create an HTML file in the vault (e.g. `app/home.html`) and upload:
-   ```bash
-   gobi vault sync
-   ```
-2. Set `homepage` in PUBLISH.md (homepage property):
-   - `homepage: "[[app/home.html]]"` — Gobi sidebars visible alongside the homepage
+A homepage is registered only after `PUBLISH.md` references it **and** the vault is re-published. Uploading the HTML alone does **not** set the homepage — `gobi vault status` will keep reporting `homepagePath: null` until you publish.
+
+1. **Create** the HTML file at a vault-root-relative path, e.g. `app/home.html` (not `_Gobi_/app/home.html` — paths are relative to the vault root).
+2. **Reference it** in `PUBLISH.md` frontmatter via the `homepage` property:
+   - `homepage: "[[app/home.html]]"` — Gobi sidebar visible alongside the homepage
    - `homepage: "[[app/home.html?nav=false]]"` — full-screen, no Gobi chrome
+3. **Upload** the HTML to webdrive:
+   ```bash
+   gobi vault sync --upload-only --path app/home.html
+   ```
+4. **Publish** so the updated frontmatter takes effect (this uploads `PUBLISH.md` and re-syncs vault metadata):
+   ```bash
+   gobi vault publish
+   ```
+5. **Verify** the homepage is registered:
+   ```bash
+   gobi --json vault status   # expect "homepagePath": "app/home.html"
+   ```
+
+> Any time you change the `homepage` frontmatter, re-run `gobi vault publish` — the file upload alone won't update the profile. See the **gobi-vault** skill for the full publishing workflow.
 
 ---
 

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.29).
+Gobi media generation commands (v2.0.30).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.29).
+Gobi sense commands for activity and transcription data (v2.0.30).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.29).
+Gobi space, global, and personal-space posts (v2.0.30).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -46,7 +46,7 @@ gobi --json vault publish
 - `gobi vault create <slug> --name <name>` — Create a new vault with the given slug and display name. Slug must be unique (use `vault list` to see what's taken). Does not change the configured vault — run `vault init` here afterwards if you want to anchor to it.
 - `gobi vault rename <newName>` — Rename the configured vault's display name. Pass `--vault-slug <slug>` to target another vault. Local handle only — the public profile title comes from `PUBLISH.md` frontmatter and is unaffected.
 - `gobi vault delete <slug>` — Delete a vault. Irreversible. Required arg, no `.gobi` fallback. The API will reject if the vault still owns content; clean up posts, members, and files first.
-- `gobi vault publish` — Upload `PUBLISH.md` to the vault root on webdrive. Triggers post-processing (vault profile sync, metadata update).
+- `gobi vault publish` — Upload `PUBLISH.md` to the vault root on webdrive. Triggers post-processing (vault profile sync, metadata update). If `PUBLISH.md` is missing (e.g. a legacy vault that only has `BRAIN.md`), a starter `PUBLISH.md` is scaffolded locally and **nothing is pushed** — fill in at least `title` and `description`, then re-run.
 - `gobi vault unpublish` — Delete `PUBLISH.md` from the vault on webdrive.
 - `gobi vault sync` — Sync local vault files with Gobi Webdrive. Supports `--upload-only`, `--download-only`, `--conflict <ask|server|client|skip>`, `--dry-run`, `--full`, `--path <p>`, `--plan-file`, `--execute`.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.29"
+  version: "2.0.30"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.29).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.30).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -4,6 +4,7 @@ import { basename, join, extname, isAbsolute, resolve } from "path";
 import ignore from "ignore";
 import { WEBDRIVE_BASE_URL } from "./constants.js";
 import { apiPost } from "./client.js";
+import { normalizeSyncPattern } from "./commands/sync.js";
 
 // Best-effort extension → MIME mapping. Anything we don't recognize falls
 // back to `application/octet-stream`; the backend caps size per content-type
@@ -136,8 +137,9 @@ function addToLocalSyncfiles(gobiDir: string, filePath: string): void {
   const patterns = readSyncfilesPatterns(gobiDir);
   if (isPathCovered(filePath, patterns)) return;
   const syncfilesPath = join(gobiDir, "syncfiles");
-  appendFileSync(syncfilesPath, `${EOL}${filePath}`);
-  console.log(`Added to syncfiles: ${filePath}`);
+  const pattern = normalizeSyncPattern(filePath);
+  appendFileSync(syncfilesPath, `${EOL}${pattern}`);
+  console.log(`Added to syncfiles: ${pattern}`);
 }
 
 export async function uploadAttachments(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -39,6 +39,16 @@ export function getVaultSlug(): string {
   return vault;
 }
 
+/**
+ * Starter PUBLISH.md frontmatter. Shared by `vault init` (seed) and
+ * `vault publish` (scaffold-on-missing) so the two paths can't drift.
+ * `description` is intentionally left blank — the vault won't list publicly
+ * until the user fills in both `title` and `description`.
+ */
+export function defaultPublishMd(title: string): string {
+  return `---\ntitle: ${title}\ntags: []\ndescription:\nthumbnail:\nprompt:\n---\n`;
+}
+
 // Per-command requirement markers. Tri-state: true / false override / inherit
 // from parent. The pre-action warning uses these to decide whether to remind
 // the user to run `gobi vault init` / `gobi space warp`.
@@ -276,11 +286,7 @@ export async function runVaultInitFlow(): Promise<void> {
   // Create default PUBLISH.md if it doesn't exist
   const publishPath = join(process.cwd(), "PUBLISH.md");
   if (!existsSync(publishPath)) {
-    writeFileSync(
-      publishPath,
-      `---\ntitle: ${vaultName}\ntags: []\ndescription:\nthumbnail:\nprompt:\n---\n`,
-      "utf-8",
-    );
+    writeFileSync(publishPath, defaultPublishMd(vaultName), "utf-8");
     console.log("Created PUBLISH.md");
   }
 }

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -25,6 +25,7 @@ import {
   saveSyncState,
   readSyncfiles,
   readPrivatefiles,
+  normalizeSyncPattern,
   runSync,
 } from "./sync.js";
 
@@ -367,6 +368,24 @@ describe("loadSyncState / saveSyncState", () => {
   });
 });
 
+describe("normalizeSyncPattern", () => {
+  it("prepends a leading slash to root-relative patterns", () => {
+    assert.equal(normalizeSyncPattern("app/home.html"), "/app/home.html");
+    assert.equal(normalizeSyncPattern("AI/Roundup/_files_/x.png"), "/AI/Roundup/_files_/x.png");
+    assert.equal(normalizeSyncPattern("PUBLISH.md"), "/PUBLISH.md");
+  });
+
+  it("leaves already-anchored patterns unchanged", () => {
+    assert.equal(normalizeSyncPattern("/app/home.html"), "/app/home.html");
+    assert.equal(normalizeSyncPattern("/notes/"), "/notes/");
+  });
+
+  it("anchors negation patterns after the '!'", () => {
+    assert.equal(normalizeSyncPattern("!app/draft.html"), "!/app/draft.html");
+    assert.equal(normalizeSyncPattern("!/app/draft.html"), "!/app/draft.html");
+  });
+});
+
 describe("readSyncfiles", () => {
   it("missing syncfiles → empty patterns, empty hash", () => {
     const { gobiDir, cleanup } = makeTempVault();
@@ -386,6 +405,19 @@ describe("readSyncfiles", () => {
     try {
       const result = readSyncfiles(gobiDir);
       assert.deepEqual(result.patterns, ["/notes/", "/docs/"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("normalizes slash-less patterns to root-anchored form", () => {
+    const { gobiDir, cleanup } = makeTempVault("app/home.html\nPUBLISH.md\n/notes/\n");
+    try {
+      assert.deepEqual(readSyncfiles(gobiDir).patterns, [
+        "/app/home.html",
+        "/PUBLISH.md",
+        "/notes/",
+      ]);
     } finally {
       cleanup();
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -246,6 +246,23 @@ export function saveSyncState(gobiDir: string, state: SyncState): void {
 
 // ─── Syncfiles ────────────────────────────────────────────────────────────────
 
+/**
+ * Webdrive requires every sync/private pattern to be root-anchored — the server
+ * rejects anything not starting with "/" (HTTP 400: "Pattern must start with
+ * '/'"). Older syncfiles, hand-edits, and `--auto-attachments` appends can all
+ * produce slash-less entries that hard-fail the whole sync with a cryptic 400,
+ * so anchor them to the vault root here. Negation patterns ("!foo") keep their
+ * leading "!". Patterns already starting with "/" are returned unchanged, so
+ * anything the server currently accepts is untouched.
+ */
+export function normalizeSyncPattern(pattern: string): string {
+  if (pattern.startsWith("!")) {
+    const rest = pattern.slice(1);
+    return rest.startsWith("/") ? pattern : `!/${rest}`;
+  }
+  return pattern.startsWith("/") ? pattern : `/${pattern}`;
+}
+
 export function readSyncfiles(gobiDir: string): { patterns: string[]; contentHash: string } {
   const syncfilesPath = join(gobiDir, "syncfiles");
   if (!existsSync(syncfilesPath)) {
@@ -255,7 +272,8 @@ export function readSyncfiles(gobiDir: string): { patterns: string[]; contentHas
   const patterns = content
     .split("\n")
     .map((l) => l.trim())
-    .filter((l) => l.length > 0 && !l.startsWith("#"));
+    .filter((l) => l.length > 0 && !l.startsWith("#"))
+    .map(normalizeSyncPattern);
   const contentHash = createHash("md5").update(content).digest("hex");
   return { patterns, contentHash };
 }
@@ -266,7 +284,8 @@ export function readPrivatefiles(gobiDir: string): string[] {
   return readFileSync(path, "utf-8")
     .split("\n")
     .map((l) => l.trim())
-    .filter((l) => l.length > 0 && !l.startsWith("#"));
+    .filter((l) => l.length > 0 && !l.startsWith("#"))
+    .map(normalizeSyncPattern);
 }
 
 export function buildWhitelistMatcher(patterns: string[]): (path: string) => boolean {

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,11 +1,11 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join, resolve as pathResolve } from "path";
 import { Command } from "commander";
 import { WEB_BASE_URL, WEBDRIVE_BASE_URL } from "../constants.js";
 import { getValidToken } from "../auth/manager.js";
 import { GobiError } from "../errors.js";
 import { apiDelete, apiGet, apiPatch, apiPost } from "../client.js";
-import { getVaultSlug, requireVault, runVaultInitFlow } from "./init.js";
+import { defaultPublishMd, getVaultSlug, requireVault, runVaultInitFlow } from "./init.js";
 import { isJsonMode, jsonOut, unwrapResp } from "./utils.js";
 import { runSync, ConflictStrategy } from "./sync.js";
 
@@ -199,7 +199,20 @@ export function registerVaultCommand(program: Command): void {
       const vaultId = getVaultSlug();
       const filePath = join(process.cwd(), PUBLISH_FILENAME);
       if (!existsSync(filePath)) {
-        throw new Error(`${PUBLISH_FILENAME} not found in ${process.cwd()}`);
+        // Scaffold a starter profile locally instead of dead-ending, but do NOT
+        // push it — an empty profile shouldn't go live without the user's review.
+        // (Legacy vaults that predate PUBLISH.md, e.g. BRAIN.md-only, land here.)
+        writeFileSync(filePath, defaultPublishMd(vaultId), "utf-8");
+        const msg =
+          `${PUBLISH_FILENAME} not found, so a starter one was created at ${filePath}. ` +
+          `Fill in at least "title" and "description" (add "homepage" too if you have a custom homepage), ` +
+          `then re-run "gobi vault publish".`;
+        if (isJsonMode(vault)) {
+          jsonOut({ vaultId, published: false, created: PUBLISH_FILENAME, message: msg });
+          return;
+        }
+        console.log(msg);
+        return;
       }
 
       const content = readFileSync(filePath, "utf-8");


### PR DESCRIPTION
## Summary
- **gobi-homepage skill**: documents the full publish flow (sync the HTML → set the `homepage` property in `PUBLISH.md` → `gobi vault publish` → verify with `gobi vault status`), so uploading the file alone no longer silently leaves `homepagePath: null`.
- **sync**: anchors `syncfiles`/`privatefiles` patterns to the vault root (`normalizeSyncPattern`) so a missing leading slash no longer hard-fails the whole sync with a cryptic `HTTP 400: Pattern must start with '/'`. `--auto-attachments` now writes anchored patterns instead of producing the bad entries.
- **vault publish**: when `PUBLISH.md` is missing (e.g. a legacy `BRAIN.md`-only vault), scaffolds a starter `PUBLISH.md` locally and stops without pushing, instead of erroring out. Template shared with `vault init`.
- Bumped to v2.0.30 (npm + Homebrew + marketplace).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 64/64 pass (incl. new `normalizeSyncPattern` + `readSyncfiles` normalization tests)
- [x] Release workflow v2.0.30 succeeded; npm published; Homebrew formula updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)