### PR TITLE
Release v2.0.34

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.33",
+      "version": "2.0.34",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.33</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.34</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.33",
+      "version": "2.0.34",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.33).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.34).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.33).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.34).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.33).
+Gobi media generation commands (v2.0.34).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.33).
+Gobi sense commands for activity and transcription data (v2.0.34).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.33).
+Gobi space, global, and personal-space posts (v2.0.34).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.33"
+  version: "2.0.34"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.33).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.34).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/sense.ts
+++ b/src/commands/sense.ts
@@ -76,30 +76,26 @@ export function registerSenseCommand(program: Command): void {
       const transcriptions = ((resp.transcriptions as unknown[]) || []) as Record<string, unknown>[];
       const lastSeenTime = resp.latestTimestamp as string | undefined;
 
-      // Flatten all turns across all transcription records into {speaker, timestamp, text}
-      interface FlatTurn { speaker: unknown; timestamp: string; text: string }
+      // Flatten all turns across transcription records. The backend returns one
+      // clean turn per entry ({speaker, timestamp, text}); `speaker` is a raw
+      // token ("0", "Mika:42", "Me:42", "uv:7", …) we turn into a label below.
+      interface FlatTurn { speaker: string; timestamp: string; text: string }
       const allTurns: FlatTurn[] = [];
 
       for (const t of transcriptions) {
         const rawTurns = ((t.turns as unknown[]) || []) as Record<string, unknown>[];
         for (const turn of rawTurns) {
-          const lines = String(turn.text ?? "").split("\n");
-          for (const line of lines) {
-            if (!line.trim() || line.trim() === "uv:") continue;
-
-            // Me@<timestamp>: <text>
-            const meMatch = line.match(/^Me@(\S+):\s*(.*)/);
-            if (meMatch) {
-              allTurns.push({ speaker: "Me", timestamp: meMatch[1], text: meMatch[2] });
-              continue;
-            }
-
-            allTurns.push({ speaker: turn.speaker, timestamp: turn.timestamp as string, text: line });
-          }
+          const text = String(turn.text ?? "").trim();
+          if (!text) continue;
+          allTurns.push({
+            speaker: String(turn.speaker ?? ""),
+            timestamp: String(turn.timestamp ?? ""),
+            text,
+          });
         }
       }
 
-      // Filter to requested time range and sort
+      // Filter to requested time range and sort by time.
       const startMs = new Date(opts.startTime).getTime();
       const endMs = new Date(opts.endTime).getTime();
       const filtered = allTurns
@@ -109,8 +105,27 @@ export function registerSenseCommand(program: Command): void {
         })
         .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
+      // Friendly speaker labels: named voices → their name, the user → "Me",
+      // anonymous voices (bare index, Person:/uv:) → a stable "Speaker N"
+      // numbered by first appearance across the sorted transcript.
+      const anonOrdinals = new Map<string, number>();
+      let nextOrdinal = 1;
+      const labelFor = (token: string): string => {
+        const named = token.match(/^(.+):(\d+)$/);
+        if (named) {
+          const name = named[1].trim();
+          if (name === "Me") return "Me";
+          if (name && name !== "Person" && name !== "uv") return name;
+        }
+        if (!anonOrdinals.has(token)) anonOrdinals.set(token, nextOrdinal++);
+        return `Speaker ${anonOrdinals.get(token)}`;
+      };
+
       if (isJsonMode(sense)) {
-        jsonOut({ transcriptions: filtered, lastSeenTime });
+        jsonOut({
+          transcriptions: filtered.map((t) => ({ ...t, speaker: labelFor(t.speaker) })),
+          lastSeenTime,
+        });
         return;
       }
 
@@ -120,7 +135,7 @@ export function registerSenseCommand(program: Command): void {
         return;
       }
 
-      const lines = filtered.map((t) => `- Speaker ${t.speaker} (${t.timestamp}): ${t.text}`);
+      const lines = filtered.map((t) => `- ${labelFor(t.speaker)} (${t.timestamp}): ${t.text}`);
       console.log(`Transcriptions (${filtered.length} turns):\n` + lines.join("\n"));
       if (lastSeenTime) console.log(`Latest data available: ${lastSeenTime}`);
     });


### PR DESCRIPTION
Release v2.0.34.

- sense: derive friendly speaker labels from raw transcription tokens (named voices → name, user → "Me", anonymous → stable "Speaker N")
- Bump version to 2.0.34 (package, plugin manifests, skill docs, cheatsheet header)

npm published, GitHub Release created, and Homebrew formula updated via the release workflow. This merge updates the Claude Marketplace (reads marketplace.json from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)