### PR TITLE
Release v2.0.35

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.34",
+      "version": "2.0.35",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.34</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.35</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.34",
+      "version": "2.0.35",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -9,12 +9,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.34).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.35).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.34).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.35).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.34).
+Gobi media generation commands (v2.0.35).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -7,12 +7,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-sense
 
-Gobi sense commands for activity and transcription data (v2.0.34).
+Gobi sense commands for activity and transcription data (v2.0.35).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-space
 
-Gobi space, global, and personal-space posts (v2.0.34).
+Gobi space, global, and personal-space posts (v2.0.35).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.34"
+  version: "2.0.35"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.34).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.35).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -2,11 +2,16 @@ import { Command } from "commander";
 import { WEB_BASE_URL } from "../constants.js";
 import { apiGet, apiPost, apiPatch, apiPut, apiDelete } from "../client.js";
 import {
+  buildMentionMap,
   formatAttachmentLines,
   formatAttachmentSummary,
+  formatPostLabel,
   formatReactionChips,
+  formatReplyLine,
   isJsonMode,
   jsonOut,
+  MentionMap,
+  postBodyText,
   readStdin,
   unwrapResp,
 } from "./utils.js";
@@ -24,7 +29,10 @@ function buildPersonalPostUrl(post: Record<string, unknown>): string {
   return `${WEB_BASE_URL}/posts/${post.id}`;
 }
 
-function formatFeedLine(m: Record<string, unknown>): string {
+function formatFeedLine(
+  m: Record<string, unknown>,
+  mentions?: MentionMap,
+): string {
   const isReply =
     m.parentPostId != null ||
     m.type === "post-reply";
@@ -35,11 +43,10 @@ function formatFeedLine(m: Record<string, unknown>): string {
     `User ${m.authorId ?? "?"}`;
   let label: string;
   if (isReply) {
-    const text = (m.content as string) || "";
+    const text = postBodyText(m, mentions).replace(/\s+/g, " ").trim();
     label = text.length > 80 ? text.slice(0, 80) + "…" : text;
-    label = label.replace(/\s+/g, " ").trim();
   } else {
-    label = (m.title as string) || (m.content as string) || "";
+    label = formatPostLabel(m, mentions);
   }
   const chips = formatReactionChips(m);
   const attachSummary = formatAttachmentSummary(m);
@@ -75,6 +82,7 @@ export function registerGlobalCommand(program: Command): void {
         jsonOut({
           items: resp.data || [],
           pagination: resp.pagination || {},
+          mentions: resp.mentions || {},
         });
         return;
       }
@@ -85,7 +93,8 @@ export function registerGlobalCommand(program: Command): void {
         console.log("No items found.");
         return;
       }
-      const lines = items.map(formatFeedLine);
+      const mentions = buildMentionMap(resp);
+      const lines = items.map((m) => formatFeedLine(m, mentions));
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
         `Global feed (${items.length} items, newest first):\n` + lines.join("\n") + footer,
@@ -112,6 +121,7 @@ export function registerGlobalCommand(program: Command): void {
         jsonOut({
           items: resp.data || [],
           pagination: resp.pagination || {},
+          mentions: resp.mentions || {},
         });
         return;
       }
@@ -122,14 +132,22 @@ export function registerGlobalCommand(program: Command): void {
         console.log("No posts found.");
         return;
       }
+      const mentions = buildMentionMap(resp);
       const lines: string[] = [];
       for (const t of items) {
         const author =
           ((t.author as Record<string, unknown>)?.name as string) ||
           `User ${t.authorId}`;
         lines.push(
-          `- [${t.id}] "${t.title}" by ${author} (${t.replyCount ?? 0} replies, ${t.createdAt})`,
+          `- [${t.id}] "${formatPostLabel(t, mentions)}" by ${author} (${t.replyCount ?? 0} replies, ${t.createdAt})`,
         );
+        for (const line of formatAttachmentLines(t, "    ", "📎")) {
+          lines.push(line);
+        }
+        const replies = (t.replies as Record<string, unknown>[]) || [];
+        for (const r of replies) {
+          lines.push(formatReplyLine(r, mentions));
+        }
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
@@ -172,6 +190,7 @@ export function registerGlobalCommand(program: Command): void {
         const post = (data.update || data.post || data) as Record<string, unknown>;
         const replies = ((data.replies as unknown[]) || []) as Record<string, unknown>[];
 
+        const mentionMap = buildMentionMap(postResp);
         const author =
           ((post.author as Record<string, unknown>)?.name as string) ||
           `User ${post.authorId}`;
@@ -179,7 +198,7 @@ export function registerGlobalCommand(program: Command): void {
         const ancestorLines: string[] = [];
         if (ancestors.length) {
           ancestors.forEach((a, i) => {
-            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a)}`);
+            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a, mentionMap)}`);
           });
         }
 
@@ -188,7 +207,7 @@ export function registerGlobalCommand(program: Command): void {
           const rAuthor =
             ((r.author as Record<string, unknown>)?.name as string) ||
             `User ${r.authorId}`;
-          const text = (r.content as string) || "";
+          const text = postBodyText(r, mentionMap);
           const truncated =
             opts.full || text.length <= 200 ? text : text.slice(0, 200) + "…";
           const rChips = formatReactionChips(r);
@@ -213,7 +232,7 @@ export function registerGlobalCommand(program: Command): void {
             ? ["", `Ancestors (${ancestors.length} items, root first):`, ...ancestorLines]
             : []),
           "",
-          (post.content as string) || "",
+          postBodyText(post, mentionMap),
           ...(attachmentLines.length
             ? ["", `Attachments (${attachmentLines.length}):`, ...attachmentLines]
             : []),

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -1,11 +1,16 @@
 import { Command } from "commander";
 import { apiGet, apiPost, apiPatch, apiPut, apiDelete } from "../client.js";
 import {
+  buildMentionMap,
   formatAttachmentLines,
   formatAttachmentSummary,
+  formatPostLabel,
   formatReactionChips,
+  formatReplyLine,
   isJsonMode,
   jsonOut,
+  MentionMap,
+  postBodyText,
   readStdin,
   unwrapResp,
 } from "./utils.js";
@@ -19,7 +24,10 @@ function readContent(value: string): string {
   return value;
 }
 
-function formatFeedLine(m: Record<string, unknown>): string {
+function formatFeedLine(
+  m: Record<string, unknown>,
+  mentions?: MentionMap,
+): string {
   const isReply =
     m.parentPostId != null ||
     m.type === "post-reply";
@@ -30,11 +38,10 @@ function formatFeedLine(m: Record<string, unknown>): string {
     `User ${m.authorId ?? "?"}`;
   let label: string;
   if (isReply) {
-    const text = (m.content as string) || "";
+    const text = postBodyText(m, mentions).replace(/\s+/g, " ").trim();
     label = text.length > 80 ? text.slice(0, 80) + "…" : text;
-    label = label.replace(/\s+/g, " ").trim();
   } else {
-    label = (m.title as string) || (m.content as string) || "";
+    label = formatPostLabel(m, mentions);
   }
   const chips = formatReactionChips(m);
   const attachSummary = formatAttachmentSummary(m);
@@ -74,6 +81,7 @@ export function registerPersonalCommand(program: Command): void {
         jsonOut({
           items: resp.data || [],
           pagination: resp.pagination || {},
+          mentions: resp.mentions || {},
         });
         return;
       }
@@ -84,7 +92,8 @@ export function registerPersonalCommand(program: Command): void {
         console.log("No items in your personal space yet.");
         return;
       }
-      const lines = items.map(formatFeedLine);
+      const mentions = buildMentionMap(resp);
+      const lines = items.map((m) => formatFeedLine(m, mentions));
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
         `Personal-space feed (${items.length} items, newest first):\n` +
@@ -127,7 +136,8 @@ export function registerPersonalCommand(program: Command): void {
         console.log("No results found.");
         return;
       }
-      const lines = items.map(formatFeedLine);
+      const mentions = buildMentionMap(resp);
+      const lines = items.map((m) => formatFeedLine(m, mentions));
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
         `Search results (${items.length} items, newest first):\n` + lines.join("\n") + footer,
@@ -170,11 +180,34 @@ export function registerPersonalCommand(program: Command): void {
         console.log("No posts found in your personal space.");
         return;
       }
+      const mentions = buildMentionMap(resp);
+      // The personal feed returns posts and replies as a flat list; group the
+      // replies under their root post so they can be nested. Falls back to an
+      // embedded `replies` array if the endpoint provides one.
+      const repliesByRoot = new Map<unknown, Record<string, unknown>[]>();
+      for (const it of allItems) {
+        if (it.type === "post-reply" || it.parentPostId != null) {
+          const root = it.rootPostId ?? it.parentPostId;
+          const arr = repliesByRoot.get(root) || [];
+          arr.push(it);
+          repliesByRoot.set(root, arr);
+        }
+      }
       const lines: string[] = [];
       for (const t of items) {
         lines.push(
-          `- [${t.id}] "${t.title ?? "(no title)"}" (${t.replyCount ?? 0} replies, ${t.createdAt})`,
+          `- [${t.id}] "${formatPostLabel(t, mentions)}" (${t.replyCount ?? 0} replies, ${t.createdAt})`,
         );
+        for (const line of formatAttachmentLines(t, "    ", "📎")) {
+          lines.push(line);
+        }
+        const replies =
+          (t.replies as Record<string, unknown>[]) ||
+          repliesByRoot.get(t.id) ||
+          [];
+        for (const r of replies) {
+          lines.push(formatReplyLine(r, mentions));
+        }
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
@@ -226,6 +259,7 @@ export function registerPersonalCommand(program: Command): void {
         const post = (data.update || data.post || data) as Record<string, unknown>;
         const replies = ((data.replies as unknown[]) || []) as Record<string, unknown>[];
 
+        const mentionMap = buildMentionMap(postResp);
         const author =
           ((post.author as Record<string, unknown>)?.name as string) ||
           `User ${post.authorId}`;
@@ -233,7 +267,7 @@ export function registerPersonalCommand(program: Command): void {
         const ancestorLines: string[] = [];
         if (ancestors.length) {
           ancestors.forEach((a, i) => {
-            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a)}`);
+            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a, mentionMap)}`);
           });
         }
 
@@ -242,7 +276,7 @@ export function registerPersonalCommand(program: Command): void {
           const rAuthor =
             ((r.author as Record<string, unknown>)?.name as string) ||
             `User ${r.authorId}`;
-          const text = (r.content as string) || "";
+          const text = postBodyText(r, mentionMap);
           const truncated =
             opts.full || text.length <= 200 ? text : text.slice(0, 200) + "…";
           const rChips = formatReactionChips(r);
@@ -267,7 +301,7 @@ export function registerPersonalCommand(program: Command): void {
             ? ["", `Ancestors (${ancestors.length} items, root first):`, ...ancestorLines]
             : []),
           "",
-          (post.content as string) || "",
+          postBodyText(post, mentionMap),
           ...(attachmentLines.length
             ? ["", `Attachments (${attachmentLines.length}):`, ...attachmentLines]
             : []),

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -8,11 +8,16 @@ import {
   writeSpaceSetting,
 } from "./init.js";
 import {
+  buildMentionMap,
   formatAttachmentLines,
   formatAttachmentSummary,
+  formatPostLabel,
   formatReactionChips,
+  formatReplyLine,
   isJsonMode,
   jsonOut,
+  MentionMap,
+  postBodyText,
   readStdin,
   resolveSpaceSlug,
   unwrapResp,
@@ -27,7 +32,10 @@ function readContent(value: string): string {
   return value;
 }
 
-function formatFeedLine(m: Record<string, unknown>): string {
+function formatFeedLine(
+  m: Record<string, unknown>,
+  mentions?: MentionMap,
+): string {
   const isReply = m.parentPostId != null;
   const id = `[${isReply ? "r" : "p"}:${m.id}]`;
   const kind = isReply ? "reply" : "post ";
@@ -36,11 +44,10 @@ function formatFeedLine(m: Record<string, unknown>): string {
     `User ${m.authorId ?? "?"}`;
   let label: string;
   if (isReply) {
-    const text = (m.content as string) || "";
+    const text = postBodyText(m, mentions).replace(/\s+/g, " ").trim();
     label = text.length > 80 ? text.slice(0, 80) + "…" : text;
-    label = label.replace(/\s+/g, " ").trim();
   } else {
-    label = (m.title as string) || (m.content as string) || "";
+    label = formatPostLabel(m, mentions);
   }
   const chips = formatReactionChips(m);
   const attachSummary = formatAttachmentSummary(m);
@@ -228,6 +235,7 @@ export function registerSpaceCommand(program: Command): void {
         return;
       }
 
+      const mentions = buildMentionMap(resp);
       const lines: string[] = [];
       for (const t of posts) {
         const author =
@@ -235,7 +243,7 @@ export function registerSpaceCommand(program: Command): void {
         const spaceName =
           ((t.space as Record<string, unknown>)?.name as string) || "";
         lines.push(
-          `- [${t.id}] "${t.title}" by ${author} in ${spaceName} (${t.replyCount} replies, ${t.createdAt})`,
+          `- [${t.id}] "${formatPostLabel(t, mentions)}" by ${author} in ${spaceName} (${t.replyCount} replies, ${t.createdAt})`,
         );
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
@@ -282,7 +290,8 @@ export function registerSpaceCommand(program: Command): void {
         console.log("No items found.");
         return;
       }
-      const lines = items.map(formatFeedLine);
+      const mentions = buildMentionMap(resp);
+      const lines = items.map((m) => formatFeedLine(m, mentions));
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
         `Feed (${items.length} items, newest first):\n` + lines.join("\n") + footer,
@@ -330,7 +339,8 @@ export function registerSpaceCommand(program: Command): void {
         console.log("No results found.");
         return;
       }
-      const lines = items.map(formatFeedLine);
+      const mentions = buildMentionMap(resp);
+      const lines = items.map((m) => formatFeedLine(m, mentions));
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(
         `Search results (${items.length} items, newest first):\n` + lines.join("\n") + footer,
@@ -368,12 +378,13 @@ export function registerSpaceCommand(program: Command): void {
           return;
         }
 
-        const post = (data.thread || data) as Record<string, unknown>;
+        const post = (data.post || data.thread || data) as Record<string, unknown>;
         const replies = ((data.items as unknown[]) || []) as Record<
           string,
           unknown
         >[];
 
+        const mentionMap = buildMentionMap(postResp);
         const author =
           ((post.author as Record<string, unknown>)?.name as string) ||
           `User ${post.authorId}`;
@@ -381,7 +392,7 @@ export function registerSpaceCommand(program: Command): void {
         const ancestorLines: string[] = [];
         if (ancestors.length) {
           ancestors.forEach((a, i) => {
-            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a)}`);
+            ancestorLines.push(`  ${i + 1}. ${formatFeedLine(a, mentionMap)}`);
           });
         }
 
@@ -390,7 +401,7 @@ export function registerSpaceCommand(program: Command): void {
           const rAuthor =
             ((r.author as Record<string, unknown>)?.name as string) ||
             `User ${r.authorId}`;
-          const text = r.content as string;
+          const text = postBodyText(r, mentionMap);
           const body =
             opts.full || !text || text.length <= 200
               ? text
@@ -417,7 +428,7 @@ export function registerSpaceCommand(program: Command): void {
             ? ["", `Ancestors (${ancestors.length} items, root first):`, ...ancestorLines]
             : []),
           "",
-          (post.content as string) || "",
+          postBodyText(post, mentionMap),
           ...(attachmentLines.length
             ? ["", `Attachments (${attachmentLines.length}):`, ...attachmentLines]
             : []),
@@ -464,15 +475,22 @@ export function registerSpaceCommand(program: Command): void {
         console.log("No posts found.");
         return;
       }
+      const mentions = buildMentionMap(resp);
       const lines: string[] = [];
       for (const t of items) {
         const author =
           ((t.author as Record<string, unknown>)?.name as string) ||
           `User ${t.authorId}`;
-        const attachSummary = formatAttachmentSummary(t);
         lines.push(
-          `- [${t.id}] "${t.title}" by ${author} (${t.replyCount} replies, ${t.createdAt})${attachSummary ? `  ${attachSummary}` : ""}`,
+          `- [${t.id}] "${formatPostLabel(t, mentions)}" by ${author} (${t.replyCount} replies, ${t.createdAt})`,
         );
+        for (const line of formatAttachmentLines(t, "    ", "📎")) {
+          lines.push(line);
+        }
+        const replies = (t.replies as Record<string, unknown>[]) || [];
+        for (const r of replies) {
+          lines.push(formatReplyLine(r, mentions));
+        }
       }
       const footer = pagination.hasMore ? `\n  Next cursor: ${pagination.nextCursor}` : "";
       console.log(

--- a/src/commands/utils.test.ts
+++ b/src/commands/utils.test.ts
@@ -1,0 +1,158 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  flattenRichText,
+  postBodyText,
+  formatPostLabel,
+  buildMentionMap,
+} from "./utils.js";
+
+describe("flattenRichText", () => {
+  it("joins text nodes", () => {
+    assert.equal(
+      flattenRichText([
+        { text: "hello ", type: "text" },
+        { text: "world", type: "text" },
+      ]),
+      "hello world",
+    );
+  });
+
+  it("renders user mentions by id when no name is present", () => {
+    assert.equal(
+      flattenRichText([
+        { text: "ping ", type: "text" },
+        { type: "user", userId: 22 },
+      ]),
+      "ping @22",
+    );
+  });
+
+  it("prefers a mention name over the id", () => {
+    assert.equal(
+      flattenRichText([{ type: "user", userId: 22, name: "mika" }]),
+      "@mika",
+    );
+  });
+
+  it("resolves a userId to a name via the mention map", () => {
+    const mentions = new Map([[278, "HyunJie Jung"]]);
+    assert.equal(
+      flattenRichText(
+        [
+          { text: "cc ", type: "text" },
+          { type: "user", userId: 278 },
+        ],
+        mentions,
+      ),
+      "cc @HyunJie Jung",
+    );
+  });
+
+  it("falls back to @id when the map lacks the user", () => {
+    assert.equal(
+      flattenRichText([{ type: "user", userId: 999 }], new Map([[1, "x"]])),
+      "@999",
+    );
+  });
+
+  it("renders link nodes as their text, falling back to the url", () => {
+    assert.equal(
+      flattenRichText([{ type: "link", url: "https://x.com", text: "x" }]),
+      "x",
+    );
+    assert.equal(
+      flattenRichText([{ type: "link", url: "https://x.com" }]),
+      "https://x.com",
+    );
+  });
+
+  it("returns empty string for non-arrays", () => {
+    assert.equal(flattenRichText(undefined), "");
+    assert.equal(flattenRichText(null), "");
+    assert.equal(flattenRichText("nope"), "");
+  });
+});
+
+describe("postBodyText", () => {
+  it("prefers non-empty content over richText", () => {
+    assert.equal(
+      postBodyText({ content: "real content", richText: [{ text: "rt", type: "text" }] }),
+      "real content",
+    );
+  });
+
+  it("falls back to richText when content is empty", () => {
+    assert.equal(
+      postBodyText({ content: "", richText: [{ text: "from rich text", type: "text" }] }),
+      "from rich text",
+    );
+  });
+
+  it("returns empty string when neither has text", () => {
+    assert.equal(postBodyText({ content: "", richText: [] }), "");
+    assert.equal(postBodyText({}), "");
+  });
+});
+
+describe("formatPostLabel", () => {
+  it("uses the title when present", () => {
+    assert.equal(formatPostLabel({ title: "Weekly Update", content: "" }), "Weekly Update");
+  });
+
+  it("never prints literal null for a titleless post", () => {
+    const label = formatPostLabel({ title: null, content: "the body" });
+    assert.equal(label, "the body");
+    assert.notEqual(label, "null");
+  });
+
+  it("falls back to a richText snippet when content is empty", () => {
+    assert.equal(
+      formatPostLabel({ title: null, content: "", richText: [{ text: "Yo Artifacts!! ", type: "text" }] }),
+      "Yo Artifacts!!",
+    );
+  });
+
+  it("shows (untitled) when there is no title or body", () => {
+    assert.equal(formatPostLabel({ title: null, content: "", richText: [] }), "(untitled)");
+  });
+
+  it("collapses whitespace and truncates long bodies", () => {
+    const long = "a".repeat(250);
+    const label = formatPostLabel({ title: null, content: long }, undefined, 100);
+    assert.equal(label.length, 101); // 100 chars + ellipsis
+    assert.ok(label.endsWith("…"));
+  });
+
+  it("resolves mentions in the body snippet", () => {
+    const mentions = new Map([[278, "HyunJie Jung"]]);
+    assert.equal(
+      formatPostLabel(
+        { title: null, content: "", richText: [{ type: "user", userId: 278 }] },
+        mentions,
+      ),
+      "@HyunJie Jung",
+    );
+  });
+});
+
+describe("buildMentionMap", () => {
+  it("builds an id -> name map from mentions.users", () => {
+    const map = buildMentionMap({
+      mentions: {
+        users: [
+          { id: 1, name: "Minsuk Kang" },
+          { id: 278, name: "HyunJie Jung" },
+        ],
+      },
+    });
+    assert.equal(map.get(1), "Minsuk Kang");
+    assert.equal(map.get(278), "HyunJie Jung");
+  });
+
+  it("returns an empty map when mentions are absent", () => {
+    assert.equal(buildMentionMap({}).size, 0);
+    assert.equal(buildMentionMap({ mentions: {} }).size, 0);
+  });
+});

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -49,6 +49,114 @@ export function formatReactionChips(m: Record<string, unknown>): string {
     .join(" ");
 }
 
+// Maps a userId to a display name, built from a response's `mentions.users`
+// block. richText `user` nodes only carry `userId`, so this resolves them to
+// names instead of printing the raw `@<id>`.
+export type MentionMap = Map<number, string>;
+
+// Build a userId -> name lookup from a list/feed/thread response's `mentions`
+// block. Returns an empty map when absent, so callers can pass it through
+// unconditionally and mentions just fall back to `@<id>`.
+export function buildMentionMap(resp: Record<string, unknown>): MentionMap {
+  const map: MentionMap = new Map();
+  // `mentions` sits at the top level on raw list/feed responses but under
+  // `data` on unwrapped thread/topic payloads — accept either.
+  const data = resp?.data as Record<string, unknown> | undefined;
+  const mentions = (resp?.mentions || data?.mentions) as
+    | Record<string, unknown>
+    | undefined;
+  const users = mentions?.users;
+  if (Array.isArray(users)) {
+    for (const u of users as Record<string, unknown>[]) {
+      if (u && typeof u.id === "number" && typeof u.name === "string") {
+        map.set(u.id, u.name);
+      }
+    }
+  }
+  return map;
+}
+
+// Flatten a richText node array into a plain-text string for display. Posts
+// commonly carry an empty `content` with the real body living only in
+// `richText`, so list/feed labels go blank without this. Renders text nodes
+// verbatim, user mentions as `@<name>` (resolved via `mentions`, else `@<id>`),
+// and link nodes as their label or URL.
+export function flattenRichText(
+  richText: unknown,
+  mentions?: MentionMap,
+): string {
+  if (!Array.isArray(richText)) return "";
+  const parts: string[] = [];
+  for (const node of richText) {
+    if (!node || typeof node !== "object") continue;
+    const n = node as Record<string, unknown>;
+    if (typeof n.text === "string" && n.text) {
+      parts.push(n.text);
+    } else if (n.type === "user") {
+      const id = n.userId;
+      const resolved =
+        (n.name as string) ||
+        (typeof id === "number" ? mentions?.get(id) : undefined) ||
+        "";
+      parts.push(
+        resolved ? `@${resolved.replace(/^@/, "")}` : id != null ? `@${id}` : "",
+      );
+    } else if (n.type === "link") {
+      parts.push((n.text as string) || (n.url as string) || (n.href as string) || "");
+    }
+  }
+  return parts.join("");
+}
+
+// Best available plain-text body for a post or reply: explicit `content` first,
+// then flattened `richText`. Empty string if neither has text.
+export function postBodyText(
+  m: Record<string, unknown>,
+  mentions?: MentionMap,
+): string {
+  const content = (m.content as string) || "";
+  if (content.trim()) return content;
+  return flattenRichText(m.richText, mentions);
+}
+
+// Single-line display label for a post: its title, else a body snippet, else
+// "(untitled)". Falls through title -> content -> richText so titleless posts
+// (the common case) read sensibly instead of printing "null"/blank. Body
+// snippets are collapsed to one line and truncated; titles are left intact.
+export function formatPostLabel(
+  m: Record<string, unknown>,
+  mentions?: MentionMap,
+  maxLen = 100,
+): string {
+  const title = (m.title as string) || "";
+  if (title.trim()) return title;
+  const body = postBodyText(m, mentions).replace(/\s+/g, " ").trim();
+  if (!body) return "(untitled)";
+  return body.length > maxLen ? body.slice(0, maxLen) + "…" : body;
+}
+
+// Compact one-line rendering of a reply for nested display under a post (used
+// by `list-posts`). Indented two levels so it reads as a child of the post
+// line; surfaces attachments/artifacts and reactions on the reply.
+export function formatReplyLine(
+  r: Record<string, unknown>,
+  mentions?: MentionMap,
+  maxLen = 200,
+): string {
+  const author =
+    ((r.author as Record<string, unknown>)?.name as string) ||
+    `User ${r.authorId ?? "?"}`;
+  const text = postBodyText(r, mentions).replace(/\s+/g, " ").trim();
+  const body = text.length > maxLen ? text.slice(0, maxLen) + "…" : text;
+  const attach = formatAttachmentSummary(r);
+  const chips = formatReactionChips(r);
+  return (
+    `    - [r:${r.id}] ${author}: ${body} (${r.createdAt})` +
+    (attach ? `  ${attach}` : "") +
+    (chips ? `  ${chips}` : "")
+  );
+}
+
 type AttachmentKind = "photo" | "gif" | "video" | "file" | "artifact" | "media";
 
 // Classify a wire attachment the way the clients do: declared mimeType first,
@@ -84,11 +192,15 @@ export function formatAttachmentSummary(m: Record<string, unknown>): string {
   return `📎 ${parts.join(", ")}`;
 }
 
-// One line per attachment with the fetchable URL — used by `get-post` so an
-// agent can download/describe the media without re-querying in --json mode.
+// One line per attachment with a fetchable reference — a `mediaUrl` for files
+// and media, or the `artifactId` for artifacts (retrievable via
+// `gobi artifact get <id>`). Used by `get-post` and nested under posts in
+// `list-posts` so an agent can fetch/describe the data without re-querying.
+// `marker` is the bullet prefix (e.g. "-" or "📎").
 export function formatAttachmentLines(
   m: Record<string, unknown>,
   indent = "  ",
+  marker = "-",
 ): string[] {
   const attachments = (m.attachments as Record<string, unknown>[]) || [];
   if (!Array.isArray(attachments) || !attachments.length) return [];
@@ -98,11 +210,11 @@ export function formatAttachmentLines(
       const art = a.artifact as Record<string, unknown>;
       const title = art.title ? ` "${art.title}"` : "";
       const status = art.isPublished ? "published" : "unpublished";
-      return `${indent}- artifact [${art.kind}]${title} (${art.artifactId}, ${status})${art.mediaUrl ? ` — ${art.mediaUrl}` : ""}`;
+      return `${indent}${marker} artifact [${art.kind}]${title} (${art.artifactId}, ${status})${art.mediaUrl ? ` — ${art.mediaUrl}` : ""}`;
     }
     const dims = a.width && a.height ? ` ${a.width}×${a.height}` : "";
     const name = a.fileName ? ` "${a.fileName}"` : "";
     const mime = a.mimeType ? ` (${a.mimeType})` : "";
-    return `${indent}- ${kind}${name}${dims}${mime} — ${a.mediaUrl}`;
+    return `${indent}${marker} ${kind}${name}${dims}${mime} — ${a.mediaUrl}`;
   });
 }


### PR DESCRIPTION
Release v2.0.35 to the Claude Marketplace (which tracks `main`).

## Changes
- **feat:** resolve @user mentions and flatten richText in feed/post display across space/personal/global; nest replies + attachments under posts in `list-posts`. Adds `utils` helpers (`postBodyText`, `flattenRichText`, `formatPostLabel`, `formatReplyLine`, `buildMentionMap`) + unit tests (`5aa6813`).
- **chore:** bump version 2.0.34 → 2.0.35 (`2a4a6bf`).

npm, GitHub Release, and Homebrew were already published from the `v2.0.35` tag. This merge updates `main` so the Claude Marketplace picks up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)