### PR TITLE
Release v2.0.39

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.36",
+  "version": "2.0.39",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.36",
+      "version": "2.0.39",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.36",
+  "version": "2.0.39",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.36</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.39</span></h1>
       <div class="tag">Spaces · Global · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">


### PR DESCRIPTION
Release v2.0.39.

Syncs `marketplace.json`, `plugin.json`, and the cheatsheet header to 2.0.39 so the Claude Marketplace and docs match the published npm version. The `v2.0.39` tag has been pushed and the npm release workflow is running.

Includes the sense refactor (space/personal `activities` + `conversations` groups, space `--mine` filter) already merged to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)