### PR TITLE
skills: drop stale @gobi / --following references (global agent + follow graph removed)

### DIFF
--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -52,7 +52,7 @@ The `-o` flag implies `--wait` and downloads the image when done.
   gobi space create-reply <postId> --content "<BODY>" --attach media/<NAME>.png
   ```
   This uploads to the CDN and renders the image as a slider on the post card. `--attach` is repeatable; mix rule is **4 photos OR 1 GIF OR 1 video**.
-- **Post-mention reply** (you were `@`-mentioned on a thread — `@gobi` / `@space:<slug>` — and your assistant body is auto-posted as the reply): **just write the text reply. Do not include the image as wiki-link, markdown image, or any URL.** The runtime detects every `gobi media generate-image` call you ran this turn and attaches those images to your auto-posted reply automatically. Embedding the image yourself either dangles (the workspace path doesn't resolve publicly) or duplicates the slider.
+- **Post-mention reply** (you were `@`-mentioned on a thread — `@space:<slug>` — and your assistant body is auto-posted as the reply): **just write the text reply. Do not include the image as wiki-link, markdown image, or any URL.** The runtime detects every `gobi media generate-image` call you ran this turn and attaches those images to your auto-posted reply automatically. Embedding the image yourself either dangles (the workspace path doesn't resolve publicly) or duplicates the slider.
 
 ### Key rules
 - Replace `<NAME>` with a descriptive slug — NEVER use example names like `sunset.png` literally.

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -143,7 +143,7 @@ Channels are private, member-gated sub-feeds inside a space. The **main feed is 
 
 `gobi personal` posts and replies are scoped to a private personal space (`personalSpaceUserId`), with the same subcommand and write-flag shape as `gobi space`. Nothing here surfaces on any public feed — these posts are visible only to you. Use for private notes-as-posts, scratch drafts, or any post you want to author against your vault without making it public.
 
-A couple of read-side flags don't mirror — `personal feed` has no `--following` (there's no follow graph in a private space), and `personal list-posts` has no `--mine` (everything in the personal space is already yours).
+One read-side flag doesn't mirror — `personal list-posts` has no `--mine` (everything in the personal space is already yours).
 
 - `gobi personal feed` — Your personal-space feed (posts and replies, newest first).
 - `gobi personal search-posts <query>` — Search your personal-space posts and replies (same `from:` / `topic:` query syntax as `gobi space search-posts`).

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -327,7 +327,7 @@ export function registerPersonalCommand(program: Command): void {
   // Targets `POST /posts/personal-space`, the only endpoint that stamps
   // `personalSpaceUserId` on the row. Body shape is identical to the public
   // `POST /posts` create (same CreatePostDto). The server skips the
-  // `@gobi` mention dispatch and the notification fan-out for this lane —
+  // agent mention dispatch and the notification fan-out for this lane —
   // private posts have no audience.
 
   personal


### PR DESCRIPTION
## Summary
- Remove leftover `@gobi` mention examples (gobi-media, gobi-space skills) and the `--following` / follow-graph note now that the @Gobi global agent and follow feature are gone.
- Reword the `personal create-post` code comment (`@gobi` → agent mention dispatch).

## Test plan
- [ ] Docs-only + one comment; no behavior change
- [ ] (separate) publish new CLI version + rebuild agent image to propagate bundled skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)