### PR TITLE
Bump version to 2.0.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump to publish the stale `@gobi` / `--following` skill-doc cleanup (PR #49) to npm. Tag `v2.0.41` after merge triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)