### PR TITLE
chore: regenerate skill docs for v2.0.41 (version stamps)

### DIFF
--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.40).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.41).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.40).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.41).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.40).
+Gobi media generation commands (v2.0.41).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.0.40).
+Gobi Sense commands for browsing activities and conversations (v2.0.41).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.0.40).
+Gobi space and personal-space posts (v2.0.41).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.40"
+  version: "2.0.41"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.40).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.41).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 


### PR DESCRIPTION
## Summary
- Fix the red `verify-skill-docs` CI job: the 2.0.41 version bump didn't regenerate the skill docs, leaving them stamped 2.0.40. Regenerated — version-stamp only, content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)