### PR TITLE
Bump version to 2.0.42 (regenerate skill docs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.41",
+      "version": "2.0.42",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.41).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.42).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.41).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.42).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.41).
+Gobi media generation commands (v2.0.42).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.0.41).
+Gobi Sense commands for browsing activities and conversations (v2.0.42).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.0.41).
+Gobi space and personal-space posts (v2.0.42).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.41"
+  version: "2.0.42"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.41).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.42).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 


### PR DESCRIPTION
Clean release: 2.0.41 published before the doc regen so npm's bundled docs carried a stale stamp. Version bump + regen together (content unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)