### PR TITLE
Release v2.0.43 — align artifact --kind with backend

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.40",
+  "version": "2.0.43",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.40",
+      "version": "2.0.43",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.40",
+  "version": "2.0.43",
   "author": {
     "name": "gobi-ai"
   },

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Like posts and artifacts, Sense data is **scoped to a space**: the subcommands l
 
 ### Artifacts
 
-An *artifact* is a versioned, human-owned creation attached to posts. Kinds: `image | video | gif | markdown | meeting_summary`. Markdown kinds carry a body; media kinds carry an uploaded file. Revisions form a draft/published tree (at most one published per artifact). Markdown kinds store `metadata.vaultSlug` for `[[wikilink]]` resolution. See the `gobi-artifact` skill for full workflows.
+An *artifact* is a versioned, human-owned creation attached to posts. Kinds: `image | video | gif | markdown | note`. Markdown kinds (`markdown`, `note`) carry a body; media kinds carry an uploaded file. Revisions form a draft/published tree (at most one published per artifact). Markdown kinds store `metadata.vaultSlug` for `[[wikilink]]` resolution. See the `gobi-artifact` skill for full workflows.
 
 Artifacts are **scoped to a space**: the subcommands live under `gobi personal artifact …` (your personal space) and `gobi space artifact …` (the active team space — `gobi space warp <slug>` or `gobi space --space-slug <slug> artifact …`). `<scope>` below is `personal` or `space`.
 
@@ -230,7 +230,7 @@ Artifacts are **scoped to a space**: the subcommands live under `gobi personal a
 |---------|-------------|
 | `gobi <scope> artifact list [--kind <k>] [--limit N]` | List this scope's artifacts (newest first) |
 | `gobi <scope> artifact get <artifactId>` | Get one artifact with its current revision |
-| `gobi <scope> artifact create --kind <k> [--file <path> \| --content <md>] [--title <t>] [--vault-slug <slug>] [--post-id <id>] [--auto-attachments] [--change-note <note>]` | Create an artifact in this scope. markdown/meeting_summary take a body via `--file`, `--content`, or stdin (`-`); image/gif/video upload `--file`. `--post-id` attaches it to a post (appends, doesn't clobber). `--auto-attachments` (markdown) uploads `[[wikilinks]]` to `--vault-slug`. |
+| `gobi <scope> artifact create --kind <k> [--file <path> \| --content <md>] [--title <t>] [--vault-slug <slug>] [--post-id <id>] [--auto-attachments] [--change-note <note>]` | Create an artifact in this scope. markdown/note take a body via `--file`, `--content`, or stdin (`-`); image/gif/video upload `--file`. `--post-id` attaches it to a post (appends, doesn't clobber). `--auto-attachments` (markdown) uploads `[[wikilinks]]` to `--vault-slug`. |
 | `gobi <scope> artifact revise <artifactId> [--file <path> \| --content <md>] [--change-note <note>] [--from <revisionId>] [--auto-attachments]` | Add a draft revision. `--from` branches off a specific revision. `--auto-attachments` reuses the artifact's stored `metadata.vaultSlug`. |
 | `gobi <scope> artifact publish <artifactId> --revision <revisionId>` | Publish a revision (the artifact's single published revision) |
 | `gobi <scope> artifact revert <artifactId> --to <revisionId>` | Move the published pointer to an earlier revision |

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.40</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.43</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.42",
+      "version": "2.0.43",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.42).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.43).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -3,7 +3,7 @@ name: gobi-artifact
 description: >-
   Gobi artifact commands for versioned creations attached to posts: create,
   revise, publish, revert, history, download, delete, get, list. An artifact
-  is a human-owned creation (image, video, gif, markdown, or meeting_summary)
+  is a human-owned creation (image, video, gif, markdown, or note)
   whose revisions form a draft/published tree. Artifacts are scoped to a space:
   `gobi personal artifact …` (your personal space) or `gobi space artifact …`
   (the active team space). Use when the user wants to author, version, publish,
@@ -40,7 +40,7 @@ artifact itself — but keep using the same scope you created the artifact in.
 
 An artifact is a versioned creation that can be attached to one or more posts. Each artifact has:
 
-- **kind** — one of `image | video | gif | markdown | meeting_summary`. `markdown` and `meeting_summary` carry a markdown **body**; `image`, `gif`, and `video` carry an uploaded **media file**.
+- **kind** — one of `image | video | gif | markdown | note`. `markdown` and `note` carry a markdown **body**; `image`, `gif`, and `video` carry an uploaded **media file**. `note` is markdown with a conventional frontmatter header (`title`, `source`, `start_time`, `end_time`, `duration`, `attendees`) that the backend mirrors into `metadata.note` on publish so clients render a structured card; the keys are all optional.
 - **title** — optional display title.
 - **owner** — always a human (the calling user). Even when an agent runs the CLI, the artifact is owned by the agent's owner.
 - **scope** — the personal space or team space it lives in (set by the command group, see above).

--- a/skills/gobi-artifact/references/personal.md
+++ b/skills/gobi-artifact/references/personal.md
@@ -10,8 +10,8 @@ Options:
   -h, --help                       display help for command
 
 Commands:
-  artifact                         Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | meeting_summary. Always
-                                   human-owned; revisions form a draft/published tree (one published per artifact).
+  artifact                         Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | note. Always human-owned;
+                                   revisions form a draft/published tree (one published per artifact).
   help [command]                   display help for command
 ```
 
@@ -20,15 +20,15 @@ Commands:
 ```
 Usage: gobi personal artifact [options] [command]
 
-Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | meeting_summary. Always human-owned; revisions form a
-draft/published tree (one published per artifact).
+Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | note. Always human-owned; revisions form a draft/published tree
+(one published per artifact).
 
 Options:
   -h, --help                       display help for command
 
 Commands:
-  create [options]                 Create an artifact. markdown/meeting_summary kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach
-                                   the new artifact to a post.
+  create [options]                 Create an artifact. markdown/note kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the new
+                                   artifact to a post.
   revise [options] <artifactId>    Add a draft revision to an artifact. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off a specific revision.
   publish [options] <artifactId>   Publish a revision (becomes the artifact's single published revision).
   revert [options] <artifactId>    Revert the artifact's published pointer to an earlier revision.

--- a/skills/gobi-artifact/references/space.md
+++ b/skills/gobi-artifact/references/space.md
@@ -10,8 +10,8 @@ Options:
   -h, --help                                  display help for command
 
 Commands:
-  artifact                                    Versioned creations attached to posts, scoped to this space (visible to its members). Kinds: image | video | gif | markdown | meeting_summary. Always
-                                              human-owned; revisions form a draft/published tree (one published per artifact).
+  artifact                                    Versioned creations attached to posts, scoped to this space (visible to its members). Kinds: image | video | gif | markdown | note. Always human-owned;
+                                              revisions form a draft/published tree (one published per artifact).
   help [command]                              display help for command
 ```
 
@@ -20,15 +20,15 @@ Commands:
 ```
 Usage: gobi space artifact [options] [command]
 
-Versioned creations attached to posts, scoped to this space (visible to its members). Kinds: image | video | gif | markdown | meeting_summary. Always human-owned; revisions form a draft/published
-tree (one published per artifact).
+Versioned creations attached to posts, scoped to this space (visible to its members). Kinds: image | video | gif | markdown | note. Always human-owned; revisions form a draft/published tree (one
+published per artifact).
 
 Options:
   -h, --help                       display help for command
 
 Commands:
-  create [options]                 Create an artifact. markdown/meeting_summary kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach
-                                   the new artifact to a post.
+  create [options]                 Create an artifact. markdown/note kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the new
+                                   artifact to a post.
   revise [options] <artifactId>    Add a draft revision to an artifact. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off a specific revision.
   publish [options] <artifactId>   Publish a revision (becomes the artifact's single published revision).
   revert [options] <artifactId>    Revert the artifact's published pointer to an earlier revision.

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.42).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.43).
 
 ## Prerequisites
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -40,7 +40,7 @@ brew tap gobi-ai/tap && brew install gobi
 - **Vault**: A filetree-backed knowledge home. A local directory becomes a vault when it contains `.gobi/settings.yaml` with a `vaultSlug`. Each vault has a slug (e.g. `brave-path-zr962w`); public profile is configured by a `PUBLISH.md` document at the vault root and pushed via `gobi vault publish`.
 - **Space Post**: A post inside a community space.
 - **Space**: A shared community knowledge area. A user can be a member of one or more spaces; each space contains posts, replies, and connected vaults.
-- **Artifact**: A versioned, human-owned creation (image, video, gif, markdown, or meeting_summary) attached to posts. Its revisions form a draft/published tree (at most one published). See the **gobi-artifact** skill.
+- **Artifact**: A versioned, human-owned creation (image, video, gif, markdown, or note) attached to posts. Its revisions form a draft/published tree (at most one published). See the **gobi-artifact** skill.
 
 ## Setup steps (run only what you need)
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.42).
+Gobi media generation commands (v2.0.43).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.0.42).
+Gobi Sense commands for browsing activities and conversations (v2.0.43).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.0.42).
+Gobi space and personal-space posts (v2.0.43).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/references/personal.md
+++ b/skills/gobi-space/references/personal.md
@@ -23,8 +23,8 @@ Commands:
   delete-reply <replyId>           Delete a reply you authored in your personal space.
   react <postId> <emoji>           Add an emoji reaction to a personal-space post or reply (idempotent). <postId> is the numeric id of a post OR a reply.
   unreact <postId> <emoji>         Remove your emoji reaction from a personal-space post or reply. <postId> is the numeric id of a post OR a reply.
-  artifact                         Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | meeting_summary. Always
-                                   human-owned; revisions form a draft/published tree (one published per artifact).
+  artifact                         Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | note. Always human-owned;
+                                   revisions form a draft/published tree (one published per artifact).
   activities                       Your personal Sense activities (what you were doing, from the wearable/app), browse-only. Recorded in your personal space (visible only to you).
   conversations                    Your personal Sense conversations (phone-mic Audio Logs + detected conversations), browse-only. Recorded in your personal space (visible only to you).
   help [command]                   display help for command
@@ -198,15 +198,15 @@ Options:
 ```
 Usage: gobi personal artifact [options] [command]
 
-Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | meeting_summary. Always human-owned; revisions form a
-draft/published tree (one published per artifact).
+Versioned creations attached to posts, scoped to your personal space (visible only to you). Kinds: image | video | gif | markdown | note. Always human-owned; revisions form a draft/published tree
+(one published per artifact).
 
 Options:
   -h, --help                       display help for command
 
 Commands:
-  create [options]                 Create an artifact. markdown/meeting_summary kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach
-                                   the new artifact to a post.
+  create [options]                 Create an artifact. markdown/note kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the new
+                                   artifact to a post.
   revise [options] <artifactId>    Add a draft revision to an artifact. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off a specific revision.
   publish [options] <artifactId>   Publish a revision (becomes the artifact's single published revision).
   revert [options] <artifactId>    Revert the artifact's published pointer to an earlier revision.

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.42"
+  version: "2.0.43"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.42).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.43).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/artifact.ts
+++ b/src/commands/artifact.ts
@@ -10,8 +10,10 @@ import { isJsonMode, jsonOut, readStdin, unwrapResp } from "./utils.js";
 import { extractWikiLinks, uploadAttachments } from "../attachments.js";
 import { getValidToken } from "../auth/manager.js";
 
-// Artifact kinds, mirrored from the backend (entities/artifact.entity.ts).
-const MARKDOWN_KINDS = ["markdown", "meeting_summary"] as const;
+// Artifact kinds, mirrored from the backend (entities/artifact.entity.ts:
+// MARKDOWN_ARTIFACT_KINDS / MEDIA_ARTIFACT_KINDS). Keep in sync — the create
+// DTO rejects anything outside this set.
+const MARKDOWN_KINDS = ["markdown", "note"] as const;
 const MEDIA_KINDS = ["image", "video", "gif"] as const;
 const ALL_KINDS = [...MEDIA_KINDS, ...MARKDOWN_KINDS] as const;
 
@@ -27,7 +29,7 @@ function isMediaKind(kind: string): boolean {
 
 // Best-effort extension → MIME mapping for artifact media uploads. Mirrors the
 // post-attachment map in attachments.ts; the backend derives the per-tier size
-// ceiling (5MB photos / 15MB GIFs / 512MB video) from the content type.
+// ceiling (10MB photos / 15MB GIFs / 512MB video) from the content type.
 const ARTIFACT_MIME_MAP: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -213,7 +215,7 @@ export function registerArtifactSubcommands(
   artifact
     .command("create")
     .description(
-      "Create an artifact. markdown/meeting_summary kinds take a body via --file, --content, or stdin (\"-\"). image/gif/video kinds upload --file. Pass --post-id to attach the new artifact to a post.",
+      "Create an artifact. markdown/note kinds take a body via --file, --content, or stdin (\"-\"). image/gif/video kinds upload --file. Pass --post-id to attach the new artifact to a post.",
     )
     .requiredOption(
       "--kind <kind>",
@@ -257,7 +259,7 @@ export function registerArtifactSubcommands(
           const content = resolveBody(opts);
           if (content == null) {
             throw new Error(
-              "markdown/meeting_summary kinds require a body via --file, --content, or stdin.",
+              "markdown/note kinds require a body via --file, --content, or stdin.",
             );
           }
           if (opts.autoAttachments) {
@@ -352,7 +354,7 @@ export function registerArtifactSubcommands(
           const content = resolveBody(opts);
           if (content == null) {
             throw new Error(
-              "markdown/meeting_summary kinds require a new body via --file, --content, or stdin.",
+              "markdown/note kinds require a new body via --file, --content, or stdin.",
             );
           }
           if (opts.autoAttachments) {

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -703,7 +703,7 @@ export function registerPersonalCommand(program: Command): void {
     personal,
     { resolve: () => ({}) },
     "Versioned creations attached to posts, scoped to your personal space (visible " +
-      "only to you). Kinds: image | video | gif | markdown | meeting_summary. Always " +
+      "only to you). Kinds: image | video | gif | markdown | note. Always " +
       "human-owned; revisions form a draft/published tree (one published per artifact).",
   );
 

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -999,7 +999,7 @@ export function registerSpaceCommand(program: Command): void {
     space,
     { resolve: () => ({ spaceSlug: resolveSpaceSlug(space) }) },
     "Versioned creations attached to posts, scoped to this space (visible to its " +
-      "members). Kinds: image | video | gif | markdown | meeting_summary. Always " +
+      "members). Kinds: image | video | gif | markdown | note. Always " +
       "human-owned; revisions form a draft/published tree (one published per artifact).",
   );
 


### PR DESCRIPTION
## Release v2.0.43

### Align `artifact --kind` with the backend
The CLI validated `--kind` against a local list that had drifted from the backend's `ArtifactKind` enum, breaking **both** directions:

- `note` was rejected client-side and never reached the backend, though the create DTO has accepted it for a while.
- `meeting_summary` was accepted and sent, but the backend removed it from the enum — so it 400'd after the round trip.

Now mirrors the backend set: `image | video | gif | markdown | note`. Also corrects a stale comment (photo ceiling is 10MB, not 5MB) and updates the README/skill docs that named `meeting_summary`.

Verified end-to-end against the real backend: created a `note` artifact, published it, and confirmed `metadata.note` was populated from the body's frontmatter (attendees list included), then deleted it.

### Release chores
Resyncs two things the 2.0.41 and 2.0.42 releases missed:
- `.claude-plugin/` manifests were still pinned at 2.0.40
- the cheatsheet header still read v2.0.40

The cheatsheet **PDF** was not rebuilt (Playwright isn't installed locally); it has been stale since the v2.0.11 era and is unchanged here.

All 82 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)