### PR TITLE
Release v2.0.45

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.44",
+      "version": "2.0.45",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.44</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.45</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.44",
+      "version": "2.0.45",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.44).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.45).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.44).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.45).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.44).
+Gobi media generation commands (v2.0.45).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.0.44).
+Gobi Sense commands for browsing activities and conversations (v2.0.45).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.0.44).
+Gobi space and personal-space posts (v2.0.45).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.44"
+  version: "2.0.45"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.44).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.45).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/utils.test.ts
+++ b/src/commands/utils.test.ts
@@ -57,6 +57,26 @@ describe("flattenRichText", () => {
     );
   });
 
+  it("prefers the live mention map over a stale node-baked name", () => {
+    assert.equal(
+      flattenRichText(
+        [{ type: "user", userId: 22, name: "old name" }],
+        new Map([[22, "New Name"]]),
+      ),
+      "@New Name",
+    );
+  });
+
+  it("renders an @here broadcast node", () => {
+    assert.equal(
+      flattenRichText([
+        { type: "here" },
+        { text: " ship it", type: "text" },
+      ]),
+      "@here ship it",
+    );
+  });
+
   it("renders link nodes as their text, falling back to the url", () => {
     assert.equal(
       flattenRichText([{ type: "link", url: "https://x.com", text: "x" }]),

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -87,8 +87,9 @@ export function buildMentionMap(resp: Record<string, unknown>): MentionMap {
 // Flatten a richText node array into a plain-text string for display. Posts
 // commonly carry an empty `content` with the real body living only in
 // `richText`, so list/feed labels go blank without this. Renders text nodes
-// verbatim, user mentions as `@<name>` (resolved via `mentions`, else `@<id>`),
-// and link nodes as their label or URL.
+// verbatim, user mentions as `@<name>` (resolved live via `mentions`, else a
+// node-baked snapshot, else `@<id>`), `@here` broadcasts, and link nodes as
+// their label or URL.
 export function flattenRichText(
   richText: unknown,
   mentions?: MentionMap,
@@ -102,13 +103,19 @@ export function flattenRichText(
       parts.push(n.text);
     } else if (n.type === "user") {
       const id = n.userId;
+      // Prefer the live name from the response's `mentions` side-channel over
+      // any `name` snapshot baked into the node, so a rename shows through;
+      // fall back to the snapshot, then the bare id. This matches every other
+      // surface (feed/web/inbox), which resolve the id at render time.
       const resolved =
-        (n.name as string) ||
         (typeof id === "number" ? mentions?.get(id) : undefined) ||
+        (n.name as string) ||
         "";
       parts.push(
         resolved ? `@${resolved.replace(/^@/, "")}` : id != null ? `@${id}` : "",
       );
+    } else if (n.type === "here") {
+      parts.push("@here");
     } else if (n.type === "link") {
       parts.push((n.text as string) || (n.url as string) || (n.href as string) || "");
     }


### PR DESCRIPTION
## Summary
- fix(cli): `flattenRichText` prefers the live `mentions` side-channel over a stale node-baked name, and renders `@here` broadcast nodes (previously dropped) — aligns the CLI with feed/web/inbox mention rendering.
- Bump to v2.0.45 (+ regenerated skill docs, cheatsheet, `.claude-plugin` manifests).

## Test plan
- [x] `npm test` — 82/82 pass (incl. new live-over-stale + @here cases)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)