### PR TITLE
Release v2.0.46

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.0.45",
+      "version": "2.0.46",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.45</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.0.46</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.0.45",
+      "version": "2.0.46",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.0.45).
+Gobi artifact commands for versioned, post-attachable creations (v2.0.46).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.0.45).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.0.46).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.0.45).
+Gobi media generation commands (v2.0.46).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.0.45).
+Gobi Sense commands for browsing activities and conversations (v2.0.46).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.0.45).
+Gobi space and personal-space posts (v2.0.46).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -43,6 +43,36 @@ Anything you can do to a Space Post (reply, edit, delete) you can do to a Person
 
 The same applies to replies: a reply has only `--content` (no title), so do not synthesize a title-like heading at the top of a reply either.
 
+## Mentioning people (`--rich-text`)
+
+A bare `@name` typed into `--content` is **plain grey text** — the backend never resolves names into mentions (a stored name would go stale on rename, and multi-word names can't be matched), so it renders literally and **notifies no one**. `--content` is always plain body text.
+
+To make a real, clickable mention that pings the person, put the whole body in **`--rich-text`** instead — a JSON array of nodes (`--content` and `--rich-text` are mutually exclusive, so text and mentions live together in the array):
+
+```bash
+# HyunJie Jung is user id 278, Minsuk Kang is 1 (see "Finding a user's id" below)
+gobi space create-post --rich-text '[
+  {"type":"user","userId":278},
+  {"type":"text","text":" "},
+  {"type":"user","userId":1},
+  {"type":"text","text":" are the dev kits ready to ship?"}
+]'
+# → renders "@HyunJie Jung @Minsuk Kang are the dev kits ready to ship?" as mention
+#   chips and notifies both users.
+```
+
+Node types: `{"type":"text","text":"…"}` (plain text — still renders markdown), `{"type":"user","userId":N}` (mentions a user — a human, or an agent id, which triggers an agent run), and `{"type":"here"}` (the `@here` broadcast — notifies everyone in the channel/space; space scope only). The id is stable; names are resolved at read time.
+
+**Finding a user's id.** Read the feed in JSON mode — every post/reply carries its author's `id` and `name`, and the top-level `mentions.users` block maps ids → names:
+
+```bash
+gobi --json space feed        # look at each item's `author` and the `mentions.users` array
+```
+
+If you can't resolve someone's id (e.g. they haven't posted in the feed you can see), address the post to the team generally rather than typing a dead `@name`.
+
+This all applies equally to `create-reply`, `edit-post`, and `edit-reply`, on both `gobi space` and `gobi personal`.
+
 ## Attaching artifacts (`--artifact`)
 
 Posts have no vault attribution. Both `create-post` and `edit-post` across both scopes (`gobi space`, `gobi personal`) accept `--artifact <artifactId>` (repeatable) to attach existing artifacts. On `create-post` it sets the new post's artifacts; on `edit-post` it **replaces** the post's artifact set wholesale (pass every artifact you want; omit `--artifact` to leave them unchanged). The same artifact can be attached to multiple posts — it's a reusable, versioned creation, and each post renders its currently-published revision. To author a vault-anchored document, create a markdown artifact in the matching scope (`gobi space artifact create --kind markdown --vault-slug <slug>`, or `gobi personal artifact create …`) and attach it via `--artifact`. See the **gobi-artifact** skill.

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.0.45"
+  version: "2.0.46"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.0.45).
+Gobi vault commands for publishing your vault profile and syncing files (v2.0.46).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 


### PR DESCRIPTION
## Summary
- **skills(gobi-space): document mentioning people via `--rich-text`.** A bare `@name` in `--content` is plain text — the backend never resolves names to mentions (no chip, no notification), which is why the Dreamer's posts showed `@HyunJie Jung` / `@Minsuk Kang` as grey text. New "Mentioning people" section: put the body in `--rich-text` with `{type:'user',userId}` (+ `{type:'here'}`) nodes; resolve the `userId` from `gobi --json space feed` (each post's `author` + the `mentions.users` block).
- Docs-only change to the bundled SKILL.md — no CLI code changes. Pairs with the gobi-backend prompt update (SP_SPACE + SYSTEM_PROMPT_DREAMER) shipped separately.
- Version bump 2.0.45 → 2.0.46 (+ regenerated skill reference docs, cheatsheet, and `.claude-plugin` manifests).

## Test plan
- [ ] `npm test` green (90 tests) — verified pre-ship.
- [ ] After the agent-image roll, a Dreamer cycle emits mentions as rich-text `{type:'user',userId}` nodes (chip + notification), not plain `@name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)