### PR TITLE
Fix release: artifact help test pinned the removed publish command

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -94,7 +94,9 @@ describe("gobi cli", () => {
     const out = run("personal", "artifact", "--help");
     assert.ok(out.includes("create"));
     assert.ok(out.includes("revise"));
-    assert.ok(out.includes("publish"));
+    // No `publish`: an artifact reads as its newest revision, so writing one is
+    // what makes it live. `revert` restores an older revision as a new one.
+    assert.ok(!out.includes("publish"));
     assert.ok(out.includes("revert"));
     assert.ok(out.includes("history"));
     assert.ok(out.includes("download"));


### PR DESCRIPTION
## Summary

The v2.2.0 release workflow failed at `npm test` (84 pass / 1 fail), before the publish step — nothing reached npm and no GitHub Release was created.

The failing test asserted that `publish` appears in `gobi personal artifact --help`. That is exactly the command removed in #58, so the test was pinning the old contract. It now asserts the command's **absence**, so the removal stays removed.

## Test plan

- [x] `npm test` — 85 pass, 0 fail (was 84/1)
- [x] `npm run build` clean
- [x] `gobi personal artifact --help` lists create/revise/revert/history/download/delete/get/list, no publish

Note: `npm test` runs `dist/*.test.js` directly with no rebuild step, so `npm run build` must precede it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)