### PR TITLE
Release v2.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, create posts and replies, generate images and videos.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.2.0</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.2.1</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact · Media</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -12,12 +12,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.2.0).
+Gobi artifact commands for versioned, post-attachable creations (v2.2.1).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.2.0).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.2.1).
 
 ## Prerequisites
 

--- a/skills/gobi-homepage/SKILL.md
+++ b/skills/gobi-homepage/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # Gobi Homepage Developer Guide

--- a/skills/gobi-media/SKILL.md
+++ b/skills/gobi-media/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-media
 
-Gobi media generation commands (v2.2.0).
+Gobi media generation commands (v2.2.1).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.2.0).
+Gobi Sense commands for browsing activities and conversations (v2.2.1).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.2.0).
+Gobi space and personal-space posts (v2.2.1).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.2.0).
+Gobi vault commands for publishing your vault profile and syncing files (v2.2.1).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,15 @@ import { BASE_URL } from "./constants.js";
 import { ApiError } from "./errors.js";
 import { getValidToken } from "./auth/manager.js";
 
+/** This machine's IANA timezone, or null when the runtime can't report one. */
+function resolveTimezone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
 async function request(
   method: string,
   path: string,
@@ -24,6 +33,14 @@ async function request(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
+  // The writer's IANA timezone. The backend reads it wherever it dispatches an
+  // agent run, so a post or reply made from the CLI gives the agent a real
+  // clock in this machine's zone rather than a bare UTC date — without it,
+  // relative windows ("last 6 hours", "today") have no origin to compute from.
+  const timezone = resolveTimezone();
+  if (timezone) {
+    headers["x-timezone"] = timezone;
+  }
   const body = options?.body != null ? JSON.stringify(options.body) : undefined;
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";


### PR DESCRIPTION
## Summary

- Sends `x-timezone` (IANA, from `Intl.DateTimeFormat().resolvedOptions().timeZone`) on every request from the CLI's `request()` header builder.
- The agent needs a clock, not just a date — Claude Code injects a bare `currentDate`, so "last 6 hours" / "today" had no origin and the space agent was building `since` windows that landed in the future and came back empty.
- An absent value degrades to the space zone, then UTC.
- Version bump 2.2.0 → 2.2.1, with regenerated skill docs, `.claude-plugin` manifests, and cheatsheet HTML.

Pairs with gobi-backend#919, which reads the header.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `.claude-plugin/plugin.json` + `marketplace.json` stamped to 2.2.1 (not touched by `npm version`)
- [x] Cheatsheet HTML diff is version-only
- [ ] `gobi space create-post` and confirm the request carries `x-timezone`
- [ ] `gobi --version` reports 2.2.1 after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)