### PR TITLE
Release v2.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, sync files, create posts and replies, and manage artifacts.",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.4.0</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.5.0</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -12,12 +12,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.4.0).
+Gobi artifact commands for versioned, post-attachable creations (v2.5.0).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.4.0).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.5.0).
 
 ## Prerequisites
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.4.0).
+Gobi Sense commands for browsing activities and conversations (v2.5.0).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -81,7 +81,9 @@ Posts have no vault attribution. Both `create-post` and `edit-post` across both 
 
 ## Post media + file attachments (`--attach`)
 
-`create-post` and `create-reply` across both scopes (`gobi space`, `gobi personal`) accept `--attach <file>` (repeatable) for inline post attachments — photos/GIF/video that render in-feed alongside the post body, and document files (**pdf/md/txt/csv**) that render as Slack-style file cards. The CLI uploads each file to S3 via `POST /posts/upload-url`; document files additionally carry `fileName` + `mimeType` on the row (the S3 key is a UUID, so that's the only place the original name survives).
+`create-post` and `create-reply` across both scopes (`gobi space`, `gobi personal`) accept `--attach <file>` (repeatable) for inline post attachments — photos/GIF/video that render in-feed alongside the post body, and document files that render as Slack-style file cards. The CLI uploads each file to S3 via `POST /posts/upload-url`; document files additionally carry `fileName` + `mimeType` on the row (the S3 key is a UUID, so that's the only place the original name survives).
+
+**Anything that isn't an image or a video is a document file** — there is no allow-list to fall outside of. `pdf`/`md`/`txt`/`csv` preview in-app, `html`/`xhtml` opens in a browser tab (it's uploaded as real `text/html`, so it renders as a page rather than downloading), `docx` is download-only, and every other type (`.zip`, `.json`, source files, extension-less files) is a generic download card on the same 250MB tier.
 
 Mix rule (enforced client-side before upload): up to **4 photos + 4 document files** together, OR **1 GIF**, OR **1 video** — GIF and video are exclusive with everything. Size ceilings: 10MB photos, 15MB GIFs, 512MB video, 250MB document files.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.4.0).
+Gobi space and personal-space posts (v2.5.0).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/references/personal.md
+++ b/skills/gobi-space/references/personal.md
@@ -99,8 +99,8 @@ Options:
   --content <content>        Post content (markdown supported, use "-" for stdin)
   --rich-text <richText>     Rich-text JSON array (mutually exclusive with --content)
   --artifact <artifactId>    Attach an existing artifact to the post (repeatable). Create artifacts with `gobi personal artifact create`. (default: [])
-  --attach <file>            Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos /
-                             15MB GIFs / 512MB video / 250MB files. (default: [])
+  --attach <file>            Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR
+                             1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
   --repost-post-id <postId>  Wrap an existing top-level post as the embedded card on this new private post. The referenced post must be visible to you (your own personal-space post, a public post, or
                              a post in a space you're a member of). Reposting someone else's personal-space post returns 404.
   -h, --help                 display help for command
@@ -117,8 +117,9 @@ Options:
   --title <title>          New title
   --content <content>      New content (markdown supported, use "-" for stdin)
   --rich-text <richText>   Rich-text JSON array (mutually exclusive with --content)
-  --attach <file>          Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv)
-                           OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged. (default: [])
+  --attach <file>          Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files
+                           (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments
+                           unchanged. (default: [])
   --artifact <artifactId>  Replace the post's artifact attachments with the given artifact(s) (existing artifact attachments are removed). Repeatable. Omit to leave them unchanged. Create artifacts
                            with `gobi personal artifact create`. (default: [])
   -h, --help               display help for command
@@ -145,8 +146,8 @@ Reply to a personal-space post. The reply inherits the parent's private scope au
 Options:
   --content <content>     Reply content (markdown supported, use "-" for stdin)
   --rich-text <richText>  Rich-text JSON array (mutually exclusive with --content)
-  --attach <file>         Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB
-                          photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
+  --attach <file>         Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type)
+                          OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
   -h, --help              display help for command
 ```
 

--- a/skills/gobi-space/references/space.md
+++ b/skills/gobi-space/references/space.md
@@ -156,8 +156,8 @@ Options:
   --artifact <artifactId>    Attach an existing artifact to the post (repeatable). Create artifacts with `gobi personal artifact create` — artifacts live in your personal core; attaching one here is
                              how you share it into the space. (default: [])
   --space-slug <spaceSlug>   Space slug (overrides .gobi/settings.yaml)
-  --attach <file>            Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos /
-                             15MB GIFs / 512MB video / 250MB files. (default: [])
+  --attach <file>            Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR
+                             1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
   --repost-post-id <postId>  Wrap an existing top-level post as the embedded card on this new post. Composes with --content / --rich-text / --attach (the wrapping author's text + media render above
                              the embedded card). Reposts-of-reposts are collapsed to the transitive root server-side. The referenced post must exist, not be deleted, and not itself be a reply.
   --channel <channelId>      Channel id to post into (see `list-channels`). Omit to post to the space's main feed. You must be able to see the channel (member, space owner/admin, or the space agent
@@ -178,7 +178,8 @@ Options:
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
   --attach <file>           Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files
-                            (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged. (default: [])
+                            (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments
+                            unchanged. (default: [])
   --artifact <artifactId>   Replace the post's artifact attachments with the given artifact(s) (existing artifact attachments are removed). Repeatable. Omit to leave them unchanged. Create artifacts
                             with `gobi personal artifact create` — artifacts live in your personal core; attaching one here is how you share it into the space. (default: [])
   -h, --help                display help for command
@@ -207,8 +208,8 @@ Options:
   --content <content>       Reply content (markdown supported, use "-" for stdin)
   --rich-text <richText>    Rich-text JSON array (mutually exclusive with --content)
   --space-slug <spaceSlug>  Space slug (overrides .gobi/settings.yaml)
-  --attach <file>           Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings:
-                            10MB photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
+  --attach <file>           Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type)
+                            OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. (default: [])
   -h, --help                display help for command
 ```
 

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.4.0).
+Gobi vault commands for publishing your vault profile and syncing files (v2.5.0).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -12,6 +12,10 @@ import { normalizeSyncPattern } from "./commands/sync.js";
 // it's the authority on what's allowed. We're just trying to set a usable
 // Content-Type for the S3 PUT — and for document files the declared MIME is
 // what routes the post row into the 'file' kind, so it must be accurate.
+// The document half mirrors POST_FILE_CONTENT_TYPES on the backend and BY_EXT
+// in gobi-web's utils/fileAttachments.ts — keep the three in sync. HTML in
+// particular must go up as real `text/html`: the clients open it in a browser
+// tab, and octet-stream makes that tab download the file instead.
 const POST_MEDIA_MIME_MAP: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -33,10 +37,50 @@ const POST_MEDIA_MIME_MAP: Record<string, string> = {
   ".markdown": "text/markdown",
   ".txt": "text/plain",
   ".csv": "text/csv",
+  ".html": "text/html",
+  ".htm": "text/html",
+  ".xhtml": "application/xhtml+xml",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 };
 
-const FILE_EXTENSIONS = [".pdf", ".md", ".markdown", ".txt", ".csv"];
 const VIDEO_EXTENSIONS = [".mp4", ".mov", ".webm", ".m4v"];
+// Still images (GIF is tracked separately — it's an exclusive kind).
+const IMAGE_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".heic",
+  ".heif",
+  ".avif",
+  ".svg",
+  ".bmp",
+  ".tiff",
+];
+
+export type AttachmentKind = "photo" | "gif" | "video" | "file";
+
+/**
+ * Classify a local path the way the server and the other clients do: only
+ * images and videos are inline media — EVERYTHING ELSE is a document 'file'
+ * attachment on the 250 MB tier. That's the backend's `kindForContentType`
+ * (post/dto/upload-post-media.dto.ts) and gobi-web's `fileTypeForFile`
+ * (utils/fileAttachments.ts) rule.
+ *
+ * Deliberately an allow-list of media rather than an allow-list of documents:
+ * classifying by "is it a known document type?" made every unrecognized
+ * extension (.html, .docx, .zip, .json, an extension-less file) fall into the
+ * photo bucket, which both capped them at 4-mixed-with-photos client-side and
+ * uploaded them as unnamed media the clients then failed to render.
+ */
+export function kindForPath(p: string): AttachmentKind {
+  const ext = extname(p).toLowerCase();
+  if (ext === ".gif") return "gif";
+  if (VIDEO_EXTENSIONS.includes(ext)) return "video";
+  if (IMAGE_EXTENSIONS.includes(ext)) return "photo";
+  return "file";
+}
 
 export type PostAttachment = {
   mediaUrl: string;
@@ -48,20 +92,27 @@ export type PostAttachment = {
 };
 
 // Mirrors the backend mix rule: up to 4 photos + up to 4 document files
-// (pdf/md/txt/csv) together, OR 1 GIF, OR 1 video — GIF and video are
-// exclusive with everything. Unknown extensions count against the photo cap
-// (the backend's 'other' kind) so nothing slips through unlimited.
+// together, OR 1 GIF, OR 1 video — GIF and video are exclusive with
+// everything else.
 export function assertPostAttachmentMix(paths: string[]): void {
   let photos = 0;
   let gifs = 0;
   let videos = 0;
   let files = 0;
   for (const p of paths) {
-    const ext = extname(p).toLowerCase();
-    if (ext === ".gif") gifs += 1;
-    else if (VIDEO_EXTENSIONS.includes(ext)) videos += 1;
-    else if (FILE_EXTENSIONS.includes(ext)) files += 1;
-    else photos += 1;
+    switch (kindForPath(p)) {
+      case "gif":
+        gifs += 1;
+        break;
+      case "video":
+        videos += 1;
+        break;
+      case "photo":
+        photos += 1;
+        break;
+      default:
+        files += 1;
+    }
   }
   if (videos > 1) throw new Error("Only 1 video allowed per post");
   if (gifs > 1) throw new Error("Only 1 GIF allowed per post");
@@ -89,6 +140,7 @@ export async function uploadPostAttachment(
   }
   const ext = extname(abs).toLowerCase();
   const contentType = POST_MEDIA_MIME_MAP[ext] || "application/octet-stream";
+  const kind = kindForPath(abs);
   const fileSize = statSync(abs).size;
   const initResp = (await apiPost("/posts/upload-url", {
     fileName: basename(abs),
@@ -114,11 +166,15 @@ export async function uploadPostAttachment(
     );
   }
   const attachment: PostAttachment = { mediaUrl, mediaKey };
-  // Document files carry name + MIME on the row: the declared mimeType is
-  // what the backend trusts for kind/preview routing, and the original
-  // filename only survives here (the S3 key is a UUID).
-  if (FILE_EXTENSIONS.includes(ext)) {
-    attachment.fileName = basename(abs);
+  // Every non-media attachment carries name + MIME on the row: the declared
+  // mimeType is what the backend trusts for kind/preview routing, and the
+  // original filename only survives here (the S3 key is a UUID). Omitting
+  // them on an unrecognized type leaves the clients no way to tell a file row
+  // from a legacy media row, so it renders as broken inline media instead of
+  // a download card. Inline media (photo/gif/video) stores neither, by design.
+  if (kind === "file") {
+    // Backend caps fileName at 255 chars — truncate rather than 400.
+    attachment.fileName = basename(abs).slice(0, 255);
     attachment.mimeType = contentType;
   }
   return attachment;

--- a/src/commands/personal.ts
+++ b/src/commands/personal.ts
@@ -349,7 +349,7 @@ export function registerPersonalCommand(program: Command): void {
     )
     .option(
       "--attach <file>",
-      "Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
+      "Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
@@ -442,7 +442,7 @@ export function registerPersonalCommand(program: Command): void {
     )
     .option(
       "--attach <file>",
-      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged.",
+      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
@@ -541,7 +541,7 @@ export function registerPersonalCommand(program: Command): void {
     )
     .option(
       "--attach <file>",
-      "Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
+      "Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )

--- a/src/commands/space.ts
+++ b/src/commands/space.ts
@@ -543,7 +543,7 @@ export function registerSpaceCommand(program: Command): void {
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--attach <file>",
-      "Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
+      "Local media or document file to attach. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
@@ -647,7 +647,7 @@ export function registerSpaceCommand(program: Command): void {
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--attach <file>",
-      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged.",
+      "Replace the post's media attachments with the given files (existing attachments are removed). Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files. Omit to leave attachments unchanged.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )
@@ -750,7 +750,7 @@ export function registerSpaceCommand(program: Command): void {
     .option("--space-slug <spaceSlug>", "Space slug (overrides .gobi/settings.yaml)")
     .option(
       "--attach <file>",
-      "Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
+      "Local media or document file to attach to this reply. Repeatable. Mix rule: up to 4 photos + up to 4 document files (pdf/md/txt/csv/html/docx, or any other non-media type) OR 1 GIF OR 1 video. Size ceilings: 10MB photos / 15MB GIFs / 512MB video / 250MB files.",
       (value: string, prev: string[] = []) => [...prev, value],
       [] as string[],
     )


### PR DESCRIPTION
## Summary

**`attach`: only images and videos are media — everything else is a file.**

The CLI classified attachments by *"is it a known document extension?"*, so every unrecognized type fell into the **photo** bucket. HTML was the visible casualty (reported as "CLI로 포스트 올릴 때 html은 attach가 안 된다"):

- `--attach page.html` counted against the 4-photo cap → mixing it with photos failed client-side with the wrong error, `Up to 4 photos allowed per post`
- it uploaded as `application/octet-stream` and carried no `fileName`/`mimeType`, leaving a nameless row the CDN then served as octet-stream — so the clients' "open in a browser tab" **downloaded** the file instead of rendering it as a page

The backend has accepted `text/html` as a first-class file type all along (`POST_FILE_CONTENT_TYPES`), and web (`previewKind: 'open-tab'`) and app (`isHtmlAttachment`) both render it. The CLI was the only client behind — and its rule was *inverted* relative to both: `kindForContentType` and gobi-web's `fileTypeForFile` allow-list **media** and treat everything else as a document file.

So this flips the rule to match rather than adding `html` to a list it would just fall off again. `kindForPath()` now drives both the mix check and the upload, fixing `.html` and `.docx` (both already backend-supported) plus `.zip`/`.json`/source/extension-less files in one move — that last group previously uploaded as unnamed media the clients failed to render at all.

## Verification (against production)

| case | before | after |
|---|---|---|
| `--attach test.html` | `fileName:null, mimeType:null` | `fileName:"…​.html", mimeType:"text/html"` |
| CDN `Content-Type` | `application/octet-stream` (downloads) | **`text/html`** (renders as a page) |
| 4 photos + 1 html | ❌ `Up to 4 photos allowed` | ✅ 5 attachments |
| `--attach t.json` | nameless broken inline media | named download card |
| video + html | blocked | blocked (unchanged) |
| 5 × txt | `Up to 4 **photos**` (wrong noun) | `Up to 4 **files**` |

All test posts were deleted after verification.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 84/84 pass
- [x] End-to-end against prod for every row in the table above
- [x] Exclusivity (video/GIF) and the 4-file cap still enforced
- [x] `--attach` help text (7 sites) + SKILL.md + regenerated reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)