### PR TITLE
docs: the CLI has no space scope for artifacts, sense or conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The programmatic interface to [Gobi](https://gobispace.com) — the agent-facing
 
 ## Why a CLI?
 
-Most Gobi capabilities are interactive surfaces (Desktop, Web, Mobile). The CLI flips that: every command is scriptable, returns structured JSON when asked, and uses headless device-code auth so an agent can run it on any host. If you're building an agent that needs to work in a user's Gobi — capture notes, post to a community space, draft a suggestion, generate an image — this is the surface.
+Most Gobi capabilities are interactive surfaces (Desktop, Web, Mobile). The CLI flips that: every command is scriptable, returns structured JSON when asked, and uses headless device-code auth so an agent can run it on any host. If you're building an agent that needs to work in a user's Gobi — sync and publish a vault, post to a community space, version an artifact, read back Sense captures — this is the surface.
 
 ## Installation
 
@@ -63,7 +63,7 @@ Each setup step unlocks a different family of commands — run only the ones the
 | Step | Unlocks |
 |------|---------|
 | `gobi auth login` | All authenticated commands |
-| `gobi vault init` | Every `gobi vault …` command (`publish`, `unpublish`, `sync`); also lets `<scope> artifact create --auto-attachments` resolve that vault automatically |
+| `gobi vault init` | Every `gobi vault …` command (`publish`, `unpublish`, `sync`); also lets `gobi personal artifact create --auto-attachments` resolve that vault automatically |
 | `gobi space warp` | Every `gobi space …` command without needing `--space-slug` |
 
 ---
@@ -177,7 +177,7 @@ A *Space* is a community knowledge area. A *Space Post* lives in one space. The 
 | `gobi space list-topic-posts <topicSlug>` | List posts tagged with a topic |
 | `gobi space list-posts` | List posts in the space |
 | `gobi space get-post <postId> [--full]` | Get a post with its ancestors and replies. `--full` shows reply content without truncation. |
-| `gobi space create-post [--title <t>] (--content <c> \| --rich-text <json>) [--artifact <artifactId>]… [--repost-post-id <id>] [--attach <file>]…` | Create a space post. Must provide content via `--content` or `--rich-text`. `--artifact` attaches an existing artifact to the post (repeatable). `--repost-post-id` reposts an existing post (sets `repostPostId` on the new post). `--attach` uploads local media to render inline in-feed (repeatable; X-style mix rule — up to 4 photos OR 1 GIF OR 1 video). |
+| `gobi space create-post [--title <t>] (--content <c> \| --rich-text <json>) [--artifact <artifactId>]… [--repost-post-id <id>] [--attach <file>]…` | Create a space post. Must provide content via `--content` or `--rich-text`. `--artifact` attaches an existing artifact to the post (repeatable). `--repost-post-id` reposts an existing post (sets `repostPostId` on the new post). `--attach` uploads local media and document files to render in-feed (repeatable; mix rule — up to 4 photos + 4 document files together, OR 1 GIF, OR 1 video). |
 | `gobi space edit-post <postId> [--title <t>] [--content <c>]` | Edit a space post. |
 | `gobi space delete-post <postId>` | Delete a space post |
 | `gobi space create-reply <postId> (--content <c> \| --rich-text <json>) [--attach <file>]…` | Create a reply to a space post. `--attach` works the same as on `create-post`. |
@@ -204,40 +204,40 @@ Private posts and replies visible only to you. Same `Post` data model and subcom
 
 Activity and conversation data captured by Gobi Sense (the wearable) and the mobile app, then ingested by the cloud pipeline. Read-only. See the `gobi-sense` skill for full workflows.
 
-Like posts and artifacts, Sense data is **scoped to a space**: the subcommands live under `gobi personal …` (your personal space) and `gobi space …` (the active team space — `gobi space warp <slug>` or `gobi space --space-slug <slug> …`). `<scope>` below is `personal` or `space`.
+Sense data lives in your **personal core**: the subcommands live under `gobi personal …` only. There is no `gobi space activities` / `gobi space conversations` — every capture lands in your personal core whatever space was active at the time.
 
-- **activities** — what you were doing (category + details, start/end times). In a team space, every member's activities show up, attributed to their recorder.
-- **conversations** — phone-mic Audio Logs plus Sense-detected conversations, each with a transcript and auto-generated summary. In a team space, every member's conversations show up, attributed to their recorder (transcript/audio stay owner-only). (This replaces the old `list-transcriptions` — transcriptions were unified into conversations.)
+- **activities** — what you were doing (category + details, start/end times). Yours alone.
+- **conversations** — phone-mic Audio Logs plus Sense-detected conversations, each with a transcript and auto-generated summary (transcript/audio stay owner-only). (This replaces the old `list-transcriptions` — transcriptions were unified into conversations.)
 
 | Command | Description |
 |---------|-------------|
-| `gobi <scope> activities list [--limit N] [--before <cursor>] [--mine]` | List Sense activities in this scope (newest first) |
-| `gobi <scope> activities get <activityId>` | Get one activity's details |
-| `gobi <scope> activities transcript <activityId>` | Get an activity's transcript (owner-only) |
-| `gobi <scope> conversations list [--limit N] [--before <cursor>] [--mine]` | List conversations captured in this scope (newest first) |
-| `gobi <scope> conversations transcript <conversationId>` | Get a conversation's transcript and summary |
-| `gobi <scope> conversations audio <conversationId>` | Get a signed URL for the recording (owner-only) |
+| `gobi personal activities list [--limit N] [--before <cursor>] [--mine]` | List Sense activities (newest first) |
+| `gobi personal activities get <activityId>` | Get one activity's details |
+| `gobi personal activities transcript <activityId>` | Get an activity's transcript (owner-only) |
+| `gobi personal conversations list` | List your conversations (newest first) |
+| `gobi personal conversations transcript <conversationId>` | Get a conversation's transcript and summary |
+| `gobi personal conversations audio <conversationId>` | Get a signed URL for the recording (owner-only) |
 
-`gobi space …` lists are a complete, fully-paginated per-space history (every member's records); add `--mine` to restrict either `list` to records you recorded. `gobi personal conversations list` is filtered from the cross-scope conversations feed, so it shows your recent personal conversations rather than a fully paginated history (`gobi personal activities list` is fully paginated).
+`gobi personal activities list` is fully paginated; `--mine` is a no-op (the lane is already all yours). `gobi personal conversations list` is filtered from the cross-scope conversations feed, so it shows your recent conversations rather than a fully paginated history, and takes no paging parameters.
 
 ### Artifacts
 
 An *artifact* is a versioned, human-owned creation attached to posts. Kinds: `image | video | gif | markdown | note`. Markdown kinds (`markdown`, `note`) carry a body; media kinds carry an uploaded file. Revisions form a history tree whose newest node is what the artifact reads as. Markdown kinds store `metadata.vaultSlug` for `[[wikilink]]` resolution. See the `gobi-artifact` skill for full workflows.
 
-Artifacts are **scoped to a space**: the subcommands live under `gobi personal artifact …` (your personal space) and `gobi space artifact …` (the active team space — `gobi space warp <slug>` or `gobi space --space-slug <slug> artifact …`). `<scope>` below is `personal` or `space`.
+Artifacts live in your **personal core**: the subcommands live under `gobi personal artifact …` only. There is no `gobi space artifact` — share one with a space by attaching it to a post.
 
 | Command | Description |
 |---------|-------------|
-| `gobi <scope> artifact list [--kind <k>] [--limit N]` | List this scope's artifacts (newest first) |
-| `gobi <scope> artifact get <artifactId>` | Get one artifact with its current revision |
-| `gobi <scope> artifact create --kind <k> [--file <path> \| --content <md>] [--title <t>] [--vault-slug <slug>] [--post-id <id>] [--auto-attachments] [--change-note <note>]` | Create an artifact in this scope. markdown/note take a body via `--file`, `--content`, or stdin (`-`); image/gif/video upload `--file`. `--post-id` attaches it to a post (appends, doesn't clobber). `--auto-attachments` (markdown) uploads `[[wikilinks]]` to `--vault-slug`. |
-| `gobi <scope> artifact revise <artifactId> [--file <path> \| --content <md>] [--change-note <note>] [--from <revisionId>] [--auto-attachments]` | Edit the artifact: records a revision and makes it the current one. `--from` branches off a specific revision. `--auto-attachments` reuses the artifact's stored `metadata.vaultSlug`. |
-| `gobi <scope> artifact revert <artifactId> --to <revisionId>` | Restore an earlier revision's content as a new revision |
-| `gobi <scope> artifact history <artifactId>` | List the full revision tree (owner only) |
-| `gobi <scope> artifact download <artifactId> [--revision <revisionId>] [--out <path>]` | Download a revision's content (markdown body to file/stdout; media bytes to file). Defaults to the current revision. |
-| `gobi <scope> artifact delete <artifactId>` | Delete an artifact and its revision tree |
+| `gobi personal artifact list [--kind <k>] [--limit N]` | List your artifacts (newest first) |
+| `gobi personal artifact get <artifactId>` | Get one artifact with its current revision |
+| `gobi personal artifact create --kind <k> [--file <path> \| --content <md>] [--title <t>] [--vault-slug <slug>] [--post-id <id>] [--auto-attachments] [--change-note <note>]` | Create an artifact in your personal core. markdown/note take a body via `--file`, `--content`, or stdin (`-`); image/gif/video upload `--file`. `--post-id` attaches it to a post (appends, doesn't clobber). `--auto-attachments` (markdown) uploads `[[wikilinks]]` to `--vault-slug`. |
+| `gobi personal artifact revise <artifactId> [--file <path> \| --content <md>] [--change-note <note>] [--from <revisionId>] [--auto-attachments]` | Edit the artifact: records a revision and makes it the current one. `--from` branches off a specific revision. `--auto-attachments` reuses the artifact's stored `metadata.vaultSlug`. |
+| `gobi personal artifact revert <artifactId> --to <revisionId>` | Restore an earlier revision's content as a new revision |
+| `gobi personal artifact history <artifactId>` | List the full revision tree (owner only) |
+| `gobi personal artifact download <artifactId> [--revision <revisionId>] [--out <path>]` | Download a revision's content (markdown body to file/stdout; media bytes to file). Defaults to the current revision. |
+| `gobi personal artifact delete <artifactId>` | Delete an artifact and its revision tree |
 
-Attach an artifact to a post at creation time with `gobi <scope> artifact create --post-id <postId>` (it merges into the post's existing artifacts without clobbering them).
+Attach an artifact to a post at creation time with `gobi personal artifact create --post-id <postId>` (it merges into the post's existing artifacts without clobbering them).
 
 ### Top-level options
 
@@ -276,8 +276,8 @@ The CLI ships a `.claude-plugin/` manifest with skills that wrap the command gro
 | `gobi-core` | Auth, update, space list/warp |
 | `gobi-vault` | `gobi vault init/list/publish/unpublish/sync` |
 | `gobi-space` | `gobi space …` and `gobi personal …` |
-| `gobi-artifact` | `gobi personal artifact …` and `gobi space artifact …` |
-| `gobi-sense` | `gobi personal activities/conversations …` and `gobi space activities/conversations …` |
+| `gobi-artifact` | `gobi personal artifact …` |
+| `gobi-sense` | `gobi personal activities/conversations …` |
 
 Each skill's `SKILL.md` is hand-written orientation; `references/` is regenerated from `--help` output by `npm run generate-skill-docs`.
 

--- a/scripts/generate-skill-docs.ts
+++ b/scripts/generate-skill-docs.ts
@@ -91,8 +91,9 @@ const SKILL_MAP: SkillConfig[] = [
   },
   {
     // Sense (activities + conversations) is no longer a top-level command —
-    // it's scoped subcommands under `gobi space` and `gobi personal`. Generate
-    // the reference from both scopes.
+    // it's scoped subcommands under `gobi personal`. The `space` entry below is
+    // inert: the generator walks real `--help` output, `gobi space` no longer
+    // registers these, so no space reference is emitted.
     dir: "gobi-sense",
     subcommands: {
       space: ["activities", "conversations"],
@@ -101,8 +102,9 @@ const SKILL_MAP: SkillConfig[] = [
   },
   {
     // Artifacts are no longer a top-level command — they're scoped subcommands
-    // under `gobi space` and `gobi personal`. Generate the artifact reference
-    // from both scopes.
+    // under `gobi personal`. The `space` entry below is inert for the same
+    // reason as gobi-sense above: `gobi space artifact` no longer exists, so no
+    // space reference is emitted.
     dir: "gobi-artifact",
     subcommands: {
       space: ["artifact"],

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -31,7 +31,7 @@ space. A space is its channels and posts.
 **To share an artifact with a space, attach it to a post:**
 
 ```bash
-ARTIFACT=$(gobi --json personal artifact create --kind markdown --title "Spec" --content ./spec.md | jq -r .artifactId)
+ARTIFACT=$(gobi --json personal artifact create --kind markdown --title "Spec" --file ./spec.md | jq -r .data.artifactId)
 gobi space create-post --content "Draft spec — feedback welcome" --artifact "$ARTIFACT"
 ```
 
@@ -46,7 +46,7 @@ An artifact is a versioned creation that can be attached to one or more posts. E
 - **kind** — one of `image | video | gif | markdown | note`. `markdown` and `note` carry a markdown **body**; `image`, `gif`, and `video` carry an uploaded **media file**. `note` is markdown with a conventional frontmatter header (`title`, `source`, `start_time`, `end_time`, `duration`, `attendees`) that the backend mirrors into `metadata.note` on write so clients render a structured card; the keys are all optional.
 - **title** — optional display title.
 - **owner** — always a human (the calling user). Even when an agent runs the CLI, the artifact is owned by the agent's owner.
-- **scope** — the personal space or team space it lives in (set by the command group, see above).
+- **scope** — always your personal core; the one command group resolves no space slug, so the backend files it there.
 - **revisions** — a history tree. The NEWEST revision is what the artifact reads as; writing one is what publishes it, and there is no separate publish step or draft state. `revise --from <revisionId>` branches off an earlier revision instead of the current one, so the history can fork.
 - **metadata** — per-kind extras. For markdown kinds, `metadata.vaultSlug` is the anchor vault used to resolve `[[wikilinks]]` in the body.
 
@@ -104,7 +104,7 @@ Image / gif / video kinds upload a local file (init → PUT → create) instead 
 gobi --json personal artifact create --kind image --file diagram.png --title "Architecture" --post-id 12345
 ```
 
-Media-file size ceilings mirror post media: 5MB photos / 15MB GIFs / 512MB video, derived from the file's content type. Revise a media artifact by uploading a replacement file:
+Media-file size ceilings mirror post media: 10MB photos / 15MB GIFs / 512MB video, derived from the file's content type. Revise a media artifact by uploading a replacement file:
 
 ```bash
 gobi --json personal artifact revise <artifactId> --file diagram-v2.png --change-note "Add cache layer"
@@ -124,9 +124,9 @@ gobi personal artifact download <artifactId> --revision <revisionId> --out image
 
 ## Attaching to a post
 
-Three ways to attach an artifact, depending on what already exists (`<scope>` is `personal` or `space`):
+Three ways to attach an artifact, depending on what already exists (`<lane>` is `personal` or `space` — the artifact commands themselves are `personal` only):
 
-1. **At artifact-create time** — `gobi <scope> artifact create … --post-id <id>` attaches the new artifact to an existing post **without clobbering** its current artifacts: the CLI reads the post's current artifact attachments, appends the new id, and writes the merged set via `PATCH /posts/:id` (`artifactIds`).
+1. **At artifact-create time** — `gobi personal artifact create … --post-id <id>` attaches the new artifact to an existing post **without clobbering** its current artifacts: the CLI reads the post's current artifact attachments, appends the new id, and writes the merged set via `PATCH /posts/:id` (`artifactIds`).
 2. **At post-create time** — `gobi <lane> create-post … --artifact <artifactId>` attaches one or more **already-created** artifacts to the new post (`--artifact` is repeatable).
 3. **Editing an existing post** — `gobi <lane> edit-post <id> --artifact <artifactId>` sets the post's artifact attachments. Unlike `create --post-id` (which merges), the post API's `artifactIds` is a **full replacement** — pass every artifact you want on the post, since omitted ones are removed (omitting `--artifact` entirely leaves them unchanged).
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -37,9 +37,9 @@ share its note artifact onto a post (see the **gobi-artifact** skill).
 ## Activities vs conversations
 
 - **activities** — a running log of what you were doing (category + details), each with a start/end time. Yours alone; transcripts are owner-only.
-- **conversations** — phone-mic Audio Log recordings plus Sense-detected conversations, each with a transcript and an auto-generated summary. In a team space, every member's conversations show up, attributed to their recorder (the transcript and `audio` signed URL stay owner-only). In your personal space, you see your own.
+- **conversations** — phone-mic Audio Log recordings plus Sense-detected conversations, each with a transcript and an auto-generated summary. You see your own; the transcript and `audio` signed URL stay owner-only.
 
-The old `gobi sense list-activities` / `gobi sense list-transcriptions` commands are gone — transcriptions were unified into **conversations**, and both concepts are now space-scoped.
+The old `gobi sense list-activities` / `gobi sense list-transcriptions` commands are gone — transcriptions were unified into **conversations**, and both concepts now live in the personal core.
 
 ## Important: JSON Mode
 
@@ -48,7 +48,7 @@ For programmatic/agent usage, always pass `--json` as a **top-level** option (be
 ```bash
 gobi --json personal activities list --limit 30
 gobi --json personal conversations list
-gobi --json space --space-slug my-team activities transcript 978
+gobi --json personal activities transcript 978
 ```
 
 JSON mode wraps the response as `{"success": true, "data": <…>}` (or `{"success": false, "error": "…"}`).
@@ -63,30 +63,29 @@ gobi --json personal activities get 978
 gobi --json personal activities transcript 978
 ```
 
-List recent conversations in a space, then read a transcript (with its summary) or grab the recording:
+List recent conversations, then read a transcript (with its summary) or grab the recording:
 
 ```bash
-gobi --json space --space-slug my-team conversations list
-gobi --json space --space-slug my-team conversations transcript 12345
-gobi --json space --space-slug my-team conversations audio 12345
+gobi --json personal conversations list
+gobi --json personal conversations transcript 12345
+gobi --json personal conversations audio 12345
 ```
 
-Both list commands are newest-first and page with `--limit` / `--before` (pass a previous response's `nextCursor` to `--before`). Scope difference: **`gobi space … activities/conversations list`** is a complete, fully-paginated per-space history (every member's records). **`gobi personal … conversations list`** is filtered from the cross-scope conversations feed, so it shows your recent personal conversations rather than a fully paginated history (`gobi personal activities list` is fully paginated).
+`gobi personal activities list` is newest-first and fully paginated with `--limit` / `--before` (pass a previous response's `nextCursor` to `--before`). **`gobi personal conversations list`** is filtered from the cross-scope conversations feed, so it shows your recent conversations rather than a fully paginated history, and takes no paging parameters.
 
 ## Available Commands
 
-Under `gobi personal …` (personal space) or `gobi space …` (active team space):
+Under `gobi personal …`:
 
 - `activities list` — List Sense activities in this scope (`--limit`, `--before`, `--mine`).
 - `activities get <activityId>` — Get one activity's details.
 - `activities transcript <activityId>` — Get an activity's transcript (owner-only).
-- `conversations list` — List conversations captured in this scope, newest first (`--limit`, `--before`, `--mine`). In a space, every member's (attributed to each recorder).
+- `conversations list` — List your conversations, newest first. (`--limit`, `--before` and `--mine` are accepted but inert here — the personal conversations feed takes no parameters.)
 - `conversations transcript <conversationId>` — Get a conversation's transcript and summary.
 - `conversations audio <conversationId>` — Get a signed URL for the recording (owner-only).
 
-All commands are read-only. In a space, `--mine` on either `list` restricts it to records **you** recorded (`user_id = you`); it's a no-op in the personal lane, which is already all yours.
+All commands are read-only. `--mine` on either `list` is a no-op — the personal lane is already all yours.
 
 ## Reference Documentation
 
 - [gobi personal](references/personal.md)
-- [gobi space](references/space.md)

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -77,7 +77,7 @@ This all applies equally to `create-reply`, `edit-post`, and `edit-reply`, on bo
 
 Posts have no vault attribution. Both `create-post` and `edit-post` across both scopes (`gobi space`, `gobi personal`) accept `--artifact <artifactId>` (repeatable) to attach existing artifacts. On `create-post` it sets the new post's artifacts; on `edit-post` it **replaces** the post's artifact set wholesale (pass every artifact you want; omit `--artifact` to leave them unchanged). The same artifact can be attached to multiple posts — it's a reusable, versioned creation, and each post renders its current revision. Artifacts themselves live in your personal core — there is no `gobi space artifact`, so create one with `gobi personal artifact create --kind markdown --vault-slug <slug>` and attach it via `--artifact`; that attachment is how a space sees it. See the **gobi-artifact** skill.
 
-> **Wiki-link uploads moved to artifacts.** The `--auto-attachments` flag that used to upload `[[wiki-linked files]]` from a post body now lives on `gobi <scope> artifact create` / `gobi <scope> artifact revise` (markdown kinds; `<scope>` is `space` or `personal`). To publish a markdown creation with resolvable wikilinks, create a markdown artifact with `--vault-slug` + `--auto-attachments` and attach it to the post (`--post-id`). See the **gobi-artifact** skill. Before relying on wikilink resolution, confirm the anchor vault is published: `gobi --json vault status --vault-slug <slug>` should report `isPublished: true`.
+> **Wiki-link uploads moved to artifacts.** The `--auto-attachments` flag that used to upload `[[wiki-linked files]]` from a post body now lives on `gobi personal artifact create` / `gobi personal artifact revise` (markdown kinds; there is no space-scoped artifact group). To publish a markdown creation with resolvable wikilinks, create a markdown artifact with `--vault-slug` + `--auto-attachments` and attach it to the post (`--post-id`). See the **gobi-artifact** skill. Before relying on wikilink resolution, confirm the anchor vault is published: `gobi --json vault status --vault-slug <slug>` should report `isPublished: true`.
 
 ## Post media + file attachments (`--attach`)
 
@@ -87,7 +87,7 @@ Posts have no vault attribution. Both `create-post` and `edit-post` across both 
 
 Mix rule (enforced client-side before upload): up to **4 photos + 4 document files** together, OR **1 GIF**, OR **1 video** — GIF and video are exclusive with everything. Size ceilings: 10MB photos, 15MB GIFs, 512MB video, 250MB document files.
 
-Use `--attach` for media/files you want shown in the post itself; use a markdown **artifact** (`gobi <scope> artifact create`, `<scope>` = `space`/`personal`) for `[[wikilinks]]`-bearing creations attached to the post.
+Use `--attach` for media/files you want shown in the post itself; use a markdown **artifact** (`gobi personal artifact create`) for `[[wikilinks]]`-bearing creations attached to the post.
 
 **Reading attachments back:** feed and list lines show a compact marker like `📎 2 photos, 1 file`; `get-post` prints an `Attachments (N):` block with one line per attachment — kind, original fileName, dimensions/MIME, and the fetchable CDN URL (artifact attachments show kind/title/artifactId instead). In `--json` mode the full `attachments` array is on every post/reply object.
 

--- a/src/commands/artifact.ts
+++ b/src/commands/artifact.ts
@@ -187,18 +187,19 @@ function printArtifact(a: Artifact): void {
   }
 }
 
-// How an artifact subcommand group resolves its scope at action time. The
-// `space` group resolves to the active space's slug; the `personal` group
-// resolves to {} (the caller's personal space — the backend's default). Only
+// How an artifact subcommand group resolves its scope at action time. The only
+// group left is `gobi personal`, which resolves to {} (the caller's personal
+// core — the backend's default); there is no space-scoped artifact group. Only
 // `create` and `list` carry the scope to the backend; the by-id leaves
 // (revise/revert/get/…) authorize off the artifact itself.
 export interface ArtifactScope {
   resolve(): { spaceSlug?: string };
 }
 
-// Registers the full `artifact` subcommand tree under `parent` (a `gobi space`
-// or `gobi personal` group). Moved here from a top-level `gobi artifact` group
-// so artifacts are scoped to a space (team or personal), matching posts.
+// Registers the full `artifact` subcommand tree under `parent` (the `gobi
+// personal` group — the only caller). Moved here from a top-level `gobi
+// artifact` group; artifacts live in the personal core and reach a space only
+// by being attached to a post.
 export function registerArtifactSubcommands(
   parent: Command,
   scope: ArtifactScope,
@@ -244,7 +245,8 @@ export function registerArtifactSubcommands(
         }
 
         const body: Record<string, unknown> = { kind };
-        // Scope the new artifact to this group's space (team) or personal space.
+        // Scope the new artifact. The only group left resolves to {}, so this
+        // never sets spaceSlug and the backend files it in the personal core.
         const { spaceSlug } = scope.resolve();
         if (spaceSlug) body.spaceSlug = spaceSlug;
         if (opts.title != null) body.title = opts.title;

--- a/src/commands/sense.ts
+++ b/src/commands/sense.ts
@@ -5,17 +5,15 @@ import { isJsonMode, jsonOut } from "./utils.js";
 // ── Scope ──
 //
 // How an activities/conversations subcommand group loads its list at action
-// time. Sense data (activities + conversations) is user-owned but tagged with
-// the space it was captured in; the two scopes differ only in which endpoint a
-// list hits, so each scope just provides the two list calls:
-//   • `space`    → the per-space routes (`/spaces/:slug/{activities,conversations}`),
-//     which return EVERY member's records, keyset-paginated.
+// time. Since the Personal Core release there is exactly ONE scope — `personal`,
+// registered by the `gobi personal` group — because every capture lands in the
+// personal core no matter which space was on screen. The indirection stays so a
+// group only has to supply its two list calls:
 //   • `personal` → the personal routes (`/app/activities` paginated;
 //     `/app/conversations` spans all the user's scopes, so it's filtered to the personal
 //     scope — spaceId 0 — client-side).
 // The by-id leaves (activity get/transcript, conversation transcript/audio) are
-// scope-independent — the backend authorizes them off the row itself — so they
-// register identically under both groups.
+// scope-independent — the backend authorizes them off the row itself.
 export interface SenseListResult {
   items: Record<string, unknown>[];
   pagination?: { hasMore?: boolean; nextCursor?: string };
@@ -92,8 +90,8 @@ function paginationFooter(pagination?: { hasMore?: boolean; nextCursor?: string 
 
 // ── Activities ──
 //
-// Registers the `activities` subcommand tree under `parent` (a `gobi space` or
-// `gobi personal` group). Replaces the old top-level `gobi sense list-activities`.
+// Registers the `activities` subcommand tree under `parent` (the `gobi personal`
+// group — the only caller). Replaces the old top-level `gobi sense list-activities`.
 export function registerActivitiesSubcommands(
   parent: Command,
   scope: SenseScope,
@@ -175,10 +173,10 @@ export function registerActivitiesSubcommands(
 
 // ── Conversations ──
 //
-// Registers the `conversations` subcommand tree under `parent`. The `space`
-// group lists via `/spaces/:slug/conversations` (every member's, keyset-paged);
-// the `personal` group lists via the cross-scope `/app/conversations` filtered
-// to the personal scope. Replaces the old top-level `gobi sense list-transcriptions`.
+// Registers the `conversations` subcommand tree under `parent` (the `gobi
+// personal` group — the only caller), which lists via the cross-scope
+// `/app/conversations` filtered to the personal scope. Replaces the old
+// top-level `gobi sense list-transcriptions`.
 export function registerConversationsSubcommands(
   parent: Command,
   scope: SenseScope,

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -10,7 +10,7 @@ export function readStdin(): string {
 
 // The top-level `--json` flag lives on the root program. Walk up the ancestry so
 // this works regardless of how deeply the calling command is nested (e.g. a
-// leaf under `gobi space artifact …`, not just a direct child of the program).
+// leaf under `gobi personal artifact …`, not just a direct child of the program).
 export function isJsonMode(cmd: Command): boolean {
   let cur: Command | null | undefined = cmd;
   while (cur) {


### PR DESCRIPTION
## Summary

Comment/doc accuracy audit. No code changes, and **no release** — no version bump, no tag, so npm/Homebrew/the agent image are untouched.

`artifact`, `activities` and `conversations` are registered only under `gobi personal`; `gobi space artifact …` is an unknown command, which `cli.test.ts` already asserts. The docs said otherwise in a dozen places:
- `SKILL.md` files advertised a team-space scope for Sense and Artifact — `gobi-sense/SKILL.md` contradicted its own lines 25-35 eight lines later, and linked `references/space.md`, which does not exist.
- `generate-skill-docs.ts` claimed it emits both scopes; only `personal.md` is produced.
- `gobi-artifact/SKILL.md` showed `--content ./spec.md` (that sets the body to the literal path — `--file` takes a path), `jq -r .artifactId` on a response shaped `{success,data}`, and a 5MB photo cap the code puts at 10MB.
- `README.md` promised draft and image-generation commands that aren't registered, and described the pre-`5e34bfc` attachment rule ("4 photos OR 1 GIF OR 1 video" — now 4 photos + 4 files).

Left alone deliberately: the stale `--limit`/`--before`/`--mine` strings in `sense.ts` are `.option()` descriptions, i.e. program output rather than comments.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Docs only; no version bump, so no release fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)