### PR TITLE
Release v2.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,12 @@
     "name": "gobi-ai"
   },
   "description": "Claude Code plugin for the Gobi collaborative knowledge platform CLI",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "plugins": [
     {
       "name": "gobi",
       "description": "Manage the Gobi collaborative knowledge platform from the command line. Publish vault profiles, sync files, create posts and replies, and manage artifacts.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "author": {
         "name": "gobi-ai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gobi",
   "description": "Manage the Gobi collaborative knowledge platform from the command line",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": {
     "name": "gobi-ai"
   },

--- a/docs/cheatsheet/gobi-cli-cheatsheet.html
+++ b/docs/cheatsheet/gobi-cli-cheatsheet.html
@@ -170,7 +170,7 @@ body{
 
   <header class="header">
     <div class="title-block">
-      <h1>Gobi CLI Cheatsheet <span class="ver">v2.5.0</span></h1>
+      <h1>Gobi CLI Cheatsheet <span class="ver">v2.5.1</span></h1>
       <div class="tag">Spaces · Personal · Vault · Sense · Artifact</div>
     </div>
     <div class="setup">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gobi-ai/cli",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobi-ai/cli",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "CLI client for the Gobi collaborative knowledge platform",
   "license": "MIT",
   "type": "module",

--- a/skills/gobi-artifact/SKILL.md
+++ b/skills/gobi-artifact/SKILL.md
@@ -12,12 +12,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.5.0"
+  version: "2.5.1"
 ---
 
 # gobi-artifact
 
-Gobi artifact commands for versioned, post-attachable creations (v2.5.0).
+Gobi artifact commands for versioned, post-attachable creations (v2.5.1).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/skills/gobi-artifact/references/personal.md
+++ b/skills/gobi-artifact/references/personal.md
@@ -29,8 +29,8 @@ Options:
   -h, --help                       display help for command
 
 Commands:
-  create [options]                 Create an artifact. markdown/note kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the new
-                                   artifact to a post.
+  create [options]                 Create an artifact. markdown/note/html kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the
+                                   new artifact to a post.
   revise [options] <artifactId>    Edit an artifact: records a revision and makes it the current one. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off
                                    a specific revision.
   revert [options] <artifactId>    Restore an earlier revision's content as a new revision, which becomes the current one.

--- a/skills/gobi-core/SKILL.md
+++ b/skills/gobi-core/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.5.0"
+  version: "2.5.1"
 ---
 
 # gobi-core
 
-Core CLI commands for the Gobi collaborative knowledge platform (v2.5.0).
+Core CLI commands for the Gobi collaborative knowledge platform (v2.5.1).
 
 ## Prerequisites
 

--- a/skills/gobi-sense/SKILL.md
+++ b/skills/gobi-sense/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.5.0"
+  version: "2.5.1"
 ---
 
 # gobi-sense
 
-Gobi Sense commands for browsing activities and conversations (v2.5.0).
+Gobi Sense commands for browsing activities and conversations (v2.5.1).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/SKILL.md
+++ b/skills/gobi-space/SKILL.md
@@ -10,12 +10,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.5.0"
+  version: "2.5.1"
 ---
 
 # gobi-space
 
-Gobi space and personal-space posts (v2.5.0).
+Gobi space and personal-space posts (v2.5.1).
 
 Requires gobi-cli installed and authenticated. See the **gobi-core** skill for setup.
 

--- a/skills/gobi-space/references/personal.md
+++ b/skills/gobi-space/references/personal.md
@@ -210,8 +210,8 @@ Options:
   -h, --help                       display help for command
 
 Commands:
-  create [options]                 Create an artifact. markdown/note kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the new
-                                   artifact to a post.
+  create [options]                 Create an artifact. markdown/note/html kinds take a body via --file, --content, or stdin ("-"). image/gif/video kinds upload --file. Pass --post-id to attach the
+                                   new artifact to a post.
   revise [options] <artifactId>    Edit an artifact: records a revision and makes it the current one. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off
                                    a specific revision.
   revert [options] <artifactId>    Restore an earlier revision's content as a new revision, which becomes the current one.

--- a/skills/gobi-vault/SKILL.md
+++ b/skills/gobi-vault/SKILL.md
@@ -8,12 +8,12 @@ description: >-
 allowed-tools: Bash(gobi:*)
 metadata:
   author: gobi-ai
-  version: "2.5.0"
+  version: "2.5.1"
 ---
 
 # gobi-vault
 
-Gobi vault commands for publishing your vault profile and syncing files (v2.5.0).
+Gobi vault commands for publishing your vault profile and syncing files (v2.5.1).
 
 Requires gobi-cli installed and authenticated. See gobi-core skill for setup.
 

--- a/src/commands/artifact.ts
+++ b/src/commands/artifact.ts
@@ -11,16 +11,22 @@ import { extractWikiLinks, uploadAttachments } from "../attachments.js";
 import { getValidToken } from "../auth/manager.js";
 
 // Artifact kinds, mirrored from the backend (entities/artifact.entity.ts:
-// MARKDOWN_ARTIFACT_KINDS / MEDIA_ARTIFACT_KINDS). Keep in sync — the create
+// TEXT_ARTIFACT_KINDS / MEDIA_ARTIFACT_KINDS). Keep in sync — the create
 // DTO rejects anything outside this set.
-const MARKDOWN_KINDS = ["markdown", "note"] as const;
+//
+// `html` is a text kind, not a markdown one: its body is a self-contained HTML
+// document that the clients render in a sandboxed frame. It takes a body the
+// same way markdown does, but resolves no wikilinks and has no vault anchor —
+// which is why the body-vs-media gate below asks "is this text", not "is this
+// markdown".
+const TEXT_KINDS = ["markdown", "note", "html"] as const;
 const MEDIA_KINDS = ["image", "video", "gif"] as const;
-const ALL_KINDS = [...MEDIA_KINDS, ...MARKDOWN_KINDS] as const;
+const ALL_KINDS = [...MEDIA_KINDS, ...TEXT_KINDS] as const;
 
 type ArtifactKind = (typeof ALL_KINDS)[number];
 
-function isMarkdownKind(kind: string): boolean {
-  return (MARKDOWN_KINDS as readonly string[]).includes(kind);
+function isTextKind(kind: string): boolean {
+  return (TEXT_KINDS as readonly string[]).includes(kind);
 }
 
 function isMediaKind(kind: string): boolean {
@@ -212,13 +218,13 @@ export function registerArtifactSubcommands(
   artifact
     .command("create")
     .description(
-      "Create an artifact. markdown/note kinds take a body via --file, --content, or stdin (\"-\"). image/gif/video kinds upload --file. Pass --post-id to attach the new artifact to a post.",
+      "Create an artifact. markdown/note/html kinds take a body via --file, --content, or stdin (\"-\"). image/gif/video kinds upload --file. Pass --post-id to attach the new artifact to a post.",
     )
     .requiredOption(
       "--kind <kind>",
       `Artifact kind: ${ALL_KINDS.join(" | ")}`,
     )
-    .option("--file <path>", "Local file: markdown body (markdown kinds) or media file (media kinds)")
+    .option("--file <path>", "Local file: text body (markdown/note/html kinds) or media file (media kinds)")
     .option("--content <md>", "Markdown body inline (markdown kinds; pass \"-\" for stdin)")
     .option("--title <t>", "Display title")
     .option("--vault-slug <slug>", "Anchor vault for [[wikilink]] resolution (markdown kinds). Stored in metadata.vaultSlug.")
@@ -253,11 +259,11 @@ export function registerArtifactSubcommands(
         if (opts.vaultSlug) body.vaultSlug = opts.vaultSlug;
         if (opts.changeNote != null) body.changeNote = opts.changeNote;
 
-        if (isMarkdownKind(kind)) {
+        if (isTextKind(kind)) {
           const content = resolveBody(opts);
           if (content == null) {
             throw new Error(
-              "markdown/note kinds require a body via --file, --content, or stdin.",
+              "markdown/note/html kinds require a body via --file, --content, or stdin.",
             );
           }
           if (opts.autoAttachments) {
@@ -274,7 +280,7 @@ export function registerArtifactSubcommands(
         } else if (isMediaKind(kind)) {
           if (!opts.file) throw new Error(`${kind} kind requires --file.`);
           if (opts.content != null) {
-            throw new Error("--content is only valid for markdown kinds.");
+            throw new Error("--content is only valid for text kinds.");
           }
           if (opts.autoAttachments) {
             throw new Error("--auto-attachments is only valid for markdown kinds.");
@@ -313,7 +319,7 @@ export function registerArtifactSubcommands(
     .description(
       "Edit an artifact: records a revision and makes it the current one. New body via --file, --content, or stdin (markdown), or --file (media). Use --from to branch off a specific revision.",
     )
-    .option("--file <path>", "Local file: markdown body (markdown kinds) or media file (media kinds)")
+    .option("--file <path>", "Local file: text body (markdown/note/html kinds) or media file (media kinds)")
     .option("--content <md>", "Markdown body inline (markdown kinds; pass \"-\" for stdin)")
     .option("--change-note <note>", "Note describing this revision")
     .option("--from <revisionId>", "Branch off this revision instead of the current one")
@@ -348,11 +354,11 @@ export function registerArtifactSubcommands(
         if (opts.changeNote != null) body.changeNote = opts.changeNote;
         if (opts.from) body.fromRevisionId = opts.from;
 
-        if (isMarkdownKind(kind)) {
+        if (isTextKind(kind)) {
           const content = resolveBody(opts);
           if (content == null) {
             throw new Error(
-              "markdown/note kinds require a new body via --file, --content, or stdin.",
+              "markdown/note/html kinds require a new body via --file, --content, or stdin.",
             );
           }
           if (opts.autoAttachments) {
@@ -372,7 +378,7 @@ export function registerArtifactSubcommands(
         } else if (isMediaKind(kind)) {
           if (!opts.file) throw new Error(`${kind} kind requires --file.`);
           if (opts.content != null) {
-            throw new Error("--content is only valid for markdown kinds.");
+            throw new Error("--content is only valid for text kinds.");
           }
           if (opts.autoAttachments) {
             throw new Error("--auto-attachments is only valid for markdown kinds.");
@@ -490,7 +496,7 @@ export function registerArtifactSubcommands(
           rev = a.revision;
         }
 
-        if (isMarkdownKind(kind)) {
+        if (isTextKind(kind)) {
           const content = rev.content ?? "";
           if (opts.out) {
             const { writeFile, mkdir } = await import("fs/promises");


### PR DESCRIPTION
## Summary
- `artifact create --kind html`. Without it the CLI rejects the kind before the request is made, which means agents — the only authors of these — cannot create one at all.
- The body-vs-media gate is now "is this text", not "is this markdown": `TEXT_KINDS = markdown | note | html`. html takes its body the same way markdown does, but resolves no wikilinks and has no vault anchor, so `--auto-attachments` on one still fails — and it fails saying the artifact has no `metadata.vaultSlug`, which is exactly the reason.
- Version 2.5.0 → **2.5.1**, with regenerated skill docs, `.claude-plugin/` manifests and the cheatsheet HTML.

Ships alongside gobi-backend (the `html` kind), gobi-web (sandboxed iframe) and gobi-app (WebView).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `generate-skill-docs` picked up the new kind in the artifact reference
- [x] `.claude-plugin/marketplace.json` + `plugin.json` hand-bumped to 2.5.1 (npm version does not touch them)
- [x] Cheatsheet HTML diff is the version line only; the PDF is not rebuilt here
- [ ] After publish: `gobi personal artifact create --kind html --content '<h1>hi</h1>'` succeeds
- [ ] Agent image rebuilt so pods run 2.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)